### PR TITLE
refactor: MainPanel

### DIFF
--- a/src/components/navigation/NavDrawer.jsx
+++ b/src/components/navigation/NavDrawer.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  List,
+  Divider,
+  Drawer,
+  Typography,
+  Box,
+  Zoom,
+  Fab,
+} from '@material-ui/core';
+import { ChevronLeft as ChevronLeftIcon } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+
+import NavGroup from './NavGroup';
+import NavItem from './NavItem';
+
+const useStyles = (drawerWidth) =>
+  makeStyles((theme) => ({
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+    drawerPaper: {
+      width: drawerWidth,
+    },
+    drawerHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      padding: theme.spacing(0, 3),
+      // necessary for content to be below app bar
+      ...theme.mixins.toolbar,
+    },
+  }))();
+
+export default function NavDrawer({
+  routes,
+  isDrawerOpen,
+  handleDrawerClose,
+  drawerWidth,
+}) {
+  const classes = useStyles(drawerWidth);
+
+  return (
+    <div>
+      {isDrawerOpen && (
+        <Box position="fixed" top={8} left={256} zIndex="modal">
+          <Zoom in={true} timeout={500}>
+            <Fab
+              id="MainPanel-fab-closeMenu"
+              size="medium"
+              color="primary"
+              onClick={handleDrawerClose}
+            >
+              <ChevronLeftIcon />
+            </Fab>
+          </Zoom>
+        </Box>
+      )}
+      <Drawer
+        className={classes.drawer}
+        variant="persistent"
+        anchor="left"
+        open={isDrawerOpen}
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <div className={classes.drawerHeader}>
+          <Typography variant="h5">Zendro</Typography>
+        </div>
+        <Divider />
+        <List>
+          {routes.map(({ label, icon: Icon, children }, i) => (
+            <NavGroup key={`${label}-${i}`} label={label} icon={<Icon />}>
+              {children?.map((item, ii) => (
+                <NavItem key={`${item.label}-${ii}`} label={item.label} />
+              ))}
+            </NavGroup>
+          ))}
+        </List>
+      </Drawer>
+    </div>
+  );
+}

--- a/src/components/navigation/NavDrawer.jsx
+++ b/src/components/navigation/NavDrawer.jsx
@@ -70,10 +70,19 @@ export default function NavDrawer({
         </div>
         <Divider />
         <List>
-          {routes.map(({ label, icon: Icon, children }, i) => (
-            <NavGroup key={`${label}-${i}`} label={label} icon={<Icon />}>
+          {routes.map(({ label, icon: Icon, children, to }, i) => (
+            <NavGroup
+              key={`${label}-${i}`}
+              label={label}
+              icon={<Icon />}
+              to={to}
+            >
               {children?.map((item, ii) => (
-                <NavItem key={`${item.label}-${ii}`} label={item.label} />
+                <NavItem
+                  key={`${item.label}-${ii}`}
+                  label={item.label}
+                  to={item.to}
+                />
               ))}
             </NavGroup>
           ))}

--- a/src/components/navigation/NavGroup.jsx
+++ b/src/components/navigation/NavGroup.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import {
+  ListItem,
+  ListItemText,
+  Typography,
+  ListItemIcon,
+  Collapse,
+  List,
+  Divider,
+} from '@material-ui/core';
+import {
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@material-ui/icons';
+
+// import { useTranslation } from 'react-i18next';
+
+const GetIcon = ({ icon }) => {
+  return icon === 'expandLess' ? (
+    <ExpandLessIcon id={'MainPanel-listItem-icon-models-expandLess'} />
+  ) : (
+    <ExpandMoreIcon id={'MainPanel-listItem-icon-models-expandMore'} />
+  );
+};
+
+export default function NavGroup(props) {
+  // const { t, i18n } = useTranslation();
+
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleNavGroupClick = () => {
+    setIsOpen(!isOpen);
+  };
+  return (
+    <>
+      <ListItem
+        button
+        id={'MainPanel-listItem-button-models'}
+        onClick={handleNavGroupClick}
+      >
+        <ListItemIcon>{props.icon}</ListItemIcon>
+        <ListItemText
+          primary={
+            <Typography
+              id={'MainPanel-listItemText-button-typography-title-models'}
+              noWrap={true}
+            >
+              <b>{props.label}</b>
+            </Typography>
+          }
+        />
+        {props.children && (
+          <GetIcon icon={isOpen ? 'expandLess' : 'expandMore'} />
+        )}
+      </ListItem>
+      <Collapse
+        id={'MainPanel-collapse-models'}
+        in={isOpen}
+        timeout="auto"
+        unmountOnExit
+      >
+        <List
+          id={'MainPanel-collapse-list-models'}
+          component="div"
+          disablePadding
+        >
+          {props.children}
+        </List>
+      </Collapse>
+      <Divider />
+    </>
+  );
+}

--- a/src/components/navigation/NavGroup.jsx
+++ b/src/components/navigation/NavGroup.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   ListItem,
   ListItemText,
@@ -23,7 +24,7 @@ const GetIcon = ({ icon }) => {
   );
 };
 
-export default function NavGroup(props) {
+export default function NavGroup({ icon, label, to, ...props }) {
   // const { t, i18n } = useTranslation();
 
   const [isOpen, setIsOpen] = useState(true);
@@ -35,17 +36,19 @@ export default function NavGroup(props) {
     <>
       <ListItem
         button
+        component={Link}
+        to={to}
         id={'MainPanel-listItem-button-models'}
         onClick={handleNavGroupClick}
       >
-        <ListItemIcon>{props.icon}</ListItemIcon>
+        <ListItemIcon>{icon}</ListItemIcon>
         <ListItemText
           primary={
             <Typography
               id={'MainPanel-listItemText-button-typography-title-models'}
               noWrap={true}
             >
-              <b>{props.label}</b>
+              <b>{label}</b>
             </Typography>
           }
         />

--- a/src/components/navigation/NavItem.jsx
+++ b/src/components/navigation/NavItem.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ListItem, ListItemText, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  nested: {
+    paddingLeft: theme.spacing(4),
+  },
+}));
+
+export default function NavItem(props) {
+  const classes = useStyles();
+  return (
+    <ListItem
+      button
+      className={classes.nested}
+      // selected={selectedIndex === model.id}
+      // onClick={(event) => {
+      //   if (selectedIndex !== model.id) {
+      //     handleIndexChange(event, { index: model.id, url: model.url });
+      //   }
+      // }}
+      {...props}
+    >
+      <ListItemText
+        primary={
+          <Typography
+            id={'MainPanel-listItemText-typography-' + props.name}
+            component="span"
+            variant="body2"
+            display="block"
+            noWrap={true}
+            color="textPrimary"
+          >
+            {props.label}
+          </Typography>
+        }
+      />
+    </ListItem>
+  );
+}

--- a/src/components/navigation/NavItem.jsx
+++ b/src/components/navigation/NavItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ListItem, ListItemText, Typography } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
@@ -8,31 +9,21 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function NavItem(props) {
+export default function NavItem({ label, name, ...props }) {
   const classes = useStyles();
   return (
-    <ListItem
-      button
-      className={classes.nested}
-      // selected={selectedIndex === model.id}
-      // onClick={(event) => {
-      //   if (selectedIndex !== model.id) {
-      //     handleIndexChange(event, { index: model.id, url: model.url });
-      //   }
-      // }}
-      {...props}
-    >
+    <ListItem button className={classes.nested} component={Link} {...props}>
       <ListItemText
         primary={
           <Typography
-            id={'MainPanel-listItemText-typography-' + props.name}
+            id={'MainPanel-listItemText-typography-' + name}
             component="span"
             variant="body2"
             display="block"
             noWrap={true}
             color="textPrimary"
           >
-            {props.label}
+            {label}
           </Typography>
         }
       />

--- a/src/components/toolbar/LanguageSwitcher.jsx
+++ b/src/components/toolbar/LanguageSwitcher.jsx
@@ -1,0 +1,71 @@
+import React, { useRef } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  IconButton,
+  Tooltip,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@material-ui/core';
+import Translate from '@material-ui/icons/TranslateRounded';
+
+const useStyles = makeStyles((theme) => ({
+  translationMenuItem: {
+    margin: theme.spacing(1),
+  },
+}));
+
+export default function LanguageSwitcher() {
+  const [translationAnchorEl, setTranslationAnchorEl] = React.useState(null);
+
+  const handleTranslationIconClick = (event) => {
+    setTranslationAnchorEl(event.currentTarget);
+  };
+
+  const handleTranslationMenuClose = () => {
+    setTranslationAnchorEl(null);
+  };
+
+  const translations = useRef([
+    { language: 'Español', lcode: 'es-MX' },
+    { language: 'English', lcode: 'en-US' },
+    { language: 'Deutsch', lcode: 'de-DE' },
+  ]);
+  const classes = useStyles();
+  return (
+    <>
+      {/* Translate.icon */}
+      <Tooltip title="Change language">
+        <IconButton
+          id={'MainPanel-iconButton-translate'}
+          color="inherit"
+          onClick={handleTranslationIconClick}
+        >
+          <Translate fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      {/* Translate.menu */}
+      <Menu
+        anchorEl={translationAnchorEl}
+        keepMounted
+        open={Boolean(translationAnchorEl)}
+        onClose={handleTranslationMenuClose}
+      >
+        {translations.current.map((translation, index) => (
+          <MenuItem
+            id={'MainPanel-menuItem-translation-' + translation.lcode}
+            className={classes.translationMenuItem}
+            key={translation.lcode}
+            // selected={index === translationSelectedIndex}
+            // onClick={event => handleTranslationMenuItemClick(event, index)}
+          >
+            <Typography variant="inherit" display="block" noWrap={true}>
+              {translation.language}
+            </Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/src/components/toolbar/LanguageSwitcher.jsx
+++ b/src/components/toolbar/LanguageSwitcher.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   IconButton,
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function LanguageSwitcher() {
-  const [translationAnchorEl, setTranslationAnchorEl] = React.useState(null);
+  const [translationAnchorEl, setTranslationAnchorEl] = useState(null);
 
   const handleTranslationIconClick = (event) => {
     setTranslationAnchorEl(event.currentTarget);
@@ -57,8 +57,6 @@ export default function LanguageSwitcher() {
             id={'MainPanel-menuItem-translation-' + translation.lcode}
             className={classes.translationMenuItem}
             key={translation.lcode}
-            // selected={index === translationSelectedIndex}
-            // onClick={event => handleTranslationMenuItemClick(event, index)}
           >
             <Typography variant="inherit" display="block" noWrap={true}>
               {translation.language}

--- a/src/components/toolbar/Topbar.jsx
+++ b/src/components/toolbar/Topbar.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
+import {
+  AppBar,
+  Toolbar,
+  Fade,
+  IconButton,
+  Button,
+  Typography,
+} from '@material-ui/core';
+import { MenuOutlined as MenuIcon } from '@material-ui/icons';
+import LanguageSwitcher from './LanguageSwitcher';
+
+const useStyles = (topBarMargin) =>
+  makeStyles((theme) => ({
+    appBar: {
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+    },
+    appBarShift: {
+      width: `calc(100% - ${topBarMargin}px)`,
+      marginLeft: topBarMargin,
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+      transition: theme.transitions.create(['width'], {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+    },
+    toolbarLeftButtons: {
+      marginLeft: 'auto',
+    },
+    hide: {
+      display: 'none',
+    },
+  }))();
+
+export default function Topbar({
+  isDrawerOpen,
+  handleDrawerOpen,
+  topBarMargin,
+}) {
+  const classes = useStyles(topBarMargin);
+
+  return (
+    <AppBar
+      position="fixed"
+      className={clsx(classes.appBar, {
+        [classes.appBarShift]: isDrawerOpen,
+      })}
+    >
+      <Toolbar>
+        {/* EXPAND DRAWER BUTTON */}
+        <Fade in={true} timeout={500}>
+          <IconButton
+            id="MainPanel-iconButton-openMenu"
+            color="inherit"
+            onClick={handleDrawerOpen}
+            edge="start"
+            className={clsx(classes.menuButton, isDrawerOpen && classes.hide)}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Fade>
+
+        {!isDrawerOpen && (
+          <Fade in={true} timeout={500}>
+            <Typography variant="h5" display="block" noWrap={true}>
+              Zendro
+            </Typography>
+          </Fade>
+        )}
+
+        <div className={classes.toolbarLeftButtons}>
+          <LanguageSwitcher />
+          {/* LOGOUT */}
+          <Button
+            id={'MainPanel-button-logout'}
+            color="inherit"
+            // onClick={() => {
+            //   closeSnackbar();
+            //   dispatch(logoutRequest());
+            //   history.push("/login");
+            // }}
+          >
+            Logout
+          </Button>
+        </div>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/src/layout/MainPanel.jsx
+++ b/src/layout/MainPanel.jsx
@@ -14,6 +14,7 @@ const routes = [
   {
     label: 'Home',
     icon: HomeIcon,
+    to: '/',
   },
   {
     label: 'Models',
@@ -21,6 +22,7 @@ const routes = [
     children: [
       {
         label: 'no_assoc',
+        to: '/models/no_assoc',
       },
     ],
   },
@@ -30,9 +32,11 @@ const routes = [
     children: [
       {
         label: 'Role',
+        to: '/admin/role',
       },
       {
         label: 'User',
+        to: '/admin/user',
       },
     ],
   },

--- a/src/layout/MainPanel.jsx
+++ b/src/layout/MainPanel.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Fade } from '@material-ui/core';
+import NavDrawer from '../components/navigation/NavDrawer';
+import Topbar from '../components/toolbar/Topbar';
+import {
+  BubbleChart as ModelsIcon,
+  HomeOutlined as HomeIcon,
+  SupervisorAccountRounded as AdminIcon,
+} from '@material-ui/icons';
+import clsx from 'clsx';
+
+const routes = [
+  {
+    label: 'Home',
+    icon: HomeIcon,
+  },
+  {
+    label: 'Models',
+    icon: ModelsIcon,
+    children: [
+      {
+        label: 'no_assoc',
+      },
+    ],
+  },
+  {
+    label: 'Admin',
+    icon: AdminIcon,
+    children: [
+      {
+        label: 'Role',
+      },
+      {
+        label: 'User',
+      },
+    ],
+  },
+];
+
+const drawerWidth = 280;
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+  contentShift: {
+    transition: theme.transitions.create(['margin', 'width'], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    marginLeft: 0,
+    width: `calc(100% - ${drawerWidth}px)`,
+  },
+  drawerHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+    justifyContent: 'flex-end',
+  },
+}));
+
+export default function MainPanel(props) {
+  const classes = useStyles();
+
+  /* open Drawer */
+  const [isDrawerOpen, setIsDrawerOpen] = useState(true);
+
+  const handleDrawerOpen = () => {
+    setIsDrawerOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setIsDrawerOpen(false);
+  };
+
+  return (
+    <Fade in={true} timeout={500}>
+      <div className={classes.root}>
+        <Topbar
+          topBarMargin={drawerWidth}
+          isDrawerOpen={isDrawerOpen}
+          handleDrawerOpen={handleDrawerOpen}
+        />
+        <NavDrawer
+          drawerWidth={drawerWidth}
+          routes={routes}
+          isDrawerOpen={isDrawerOpen}
+          handleDrawerClose={handleDrawerClose}
+        />
+        <main
+          className={clsx(classes.content, {
+            [classes.contentShift]: isDrawerOpen,
+          })}
+        >
+          <div className={classes.drawerHeader} />
+          {props.children}
+        </main>
+      </div>
+    </Fade>
+  );
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,18 +1,15 @@
 import { Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
-// import PrivateRoute from './PrivateRoute';
+import PrivateRoute from './PrivateRoute';
 import Login from '../pages/LoginPage';
 import NotFoundPage from '../pages/NotFoundPage';
 import ModelRoutes from './ModelRoutes';
-
-// const ModelHome = () => <div>Home works!</div>;
 
 const AppSwitch: React.FC = () => {
   return (
     <Suspense fallback={<div />}>
       <Switch>
-        {/* <PrivateRoute exact path="/" component={ModelHome} /> */}
-        <Route exact path="/" component={ModelRoutes} />
+        <PrivateRoute exact path="/" component={ModelRoutes} />
         <Route exact path="/login" component={Login} />
         <Route path="*" component={NotFoundPage} />
       </Switch>

--- a/src/routes/ModelRoutes.tsx
+++ b/src/routes/ModelRoutes.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { Switch, Route } from 'react-router-dom';
-import PrivateRoute from './PrivateRoute';
+import MainPanel from '../layout/MainPanel';
 
 interface Props {
   path: string;
@@ -10,8 +10,10 @@ const ModelHome = () => <div>Home works!</div>;
 
 export default function ModelRoutes({ path }: Props): ReactElement {
   return (
-    <Switch>
-      <PrivateRoute exact path={path} component={ModelHome} />
-    </Switch>
+    <MainPanel>
+      <Switch>
+        <Route exact path={path} component={ModelHome} />
+      </Switch>
+    </MainPanel>
   );
 }

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,29 +1,16 @@
-import { Redirect, Route, RouteProps } from 'react-router-dom';
+import { Redirect, Route, RouteProps, useLocation } from 'react-router-dom';
 import { userIsAuthenticated } from '../utils/auth';
 
-interface PrivateRouteProps extends RouteProps {
-  component: React.FC;
-}
-
-const PrivateRoute: React.FC<PrivateRouteProps> = ({
-  component: Component,
-  ...routeProps
-}) => {
-  return (
-    <Route
-      {...routeProps}
-      render={({ location }) =>
-        userIsAuthenticated() && location.pathname !== '/login' ? (
-          <Component />
-        ) : (
-          <Redirect
-            to={{
-              pathname: '/login',
-              state: { from: location },
-            }}
-          />
-        )
-      }
+const PrivateRoute: React.FC<RouteProps> = ({ ...routeProps }) => {
+  const location = useLocation();
+  return userIsAuthenticated() && location.pathname !== '/login' ? (
+    <Route {...routeProps} />
+  ) : (
+    <Redirect
+      to={{
+        pathname: '/login',
+        state: { from: location },
+      }}
     />
   );
 };


### PR DESCRIPTION
## Description

This PR implements a refactor of the MainPanel. Instead of on monolithic MainPanel, components have been abstracted away into generic ones.
Also implements correct private routing of the Model routes

### New Components
#### Navigation
- NavDrawer: generic Drawer component that takes routes and renders them into NavGroups and NavItems
- NavGroup: generic collapsable container for the NavItems
- NavItem: generic Navigation route.

#### TopBar
- TopBar: static Appbar component with the zendro Layout
- LanguageSwitcher
