### PR TITLE
Use dialog hook

### DIFF
--- a/src/components/dialog/dialog-context.ts
+++ b/src/components/dialog/dialog-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createContext } from 'react';
 import { DialogOptions, AlertOptions, MessageOptions } from '@/types/dialog';
 
 export interface DialogContext {
@@ -15,4 +15,4 @@ const DEFAULT_CONTEXT: DialogContext = {
   close: () => null,
 };
 
-export const DialogContext = React.createContext(DEFAULT_CONTEXT);
+export const DialogContext = createContext(DEFAULT_CONTEXT);

--- a/src/components/dialog/dialog-context.ts
+++ b/src/components/dialog/dialog-context.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { DialogOptions, AlertOptions, MessageOptions } from '@/types/dialog';
+
+export interface DialogContext {
+  openConfirm: (options: DialogOptions) => void;
+  openAlert: (options: AlertOptions) => void;
+  openMessage: (options: MessageOptions) => void;
+  close: () => void;
+}
+
+const DEFAULT_CONTEXT: DialogContext = {
+  openConfirm: () => null,
+  openAlert: () => null,
+  openMessage: () => null,
+  close: () => null,
+};
+
+export const DialogContext = React.createContext(DEFAULT_CONTEXT);

--- a/src/components/dialog/dialog-provider.tsx
+++ b/src/components/dialog/dialog-provider.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 import {
   Box,
@@ -18,6 +17,7 @@ import {
 } from '@/types/dialog';
 import { DialogContext } from '@/components/dialog/dialog-context';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
 
 const DEFAULT_OK_COLOR = 'primary';
 const DEFAULT_CANCEL_COLOR = 'secondary';
@@ -54,10 +54,6 @@ export const DialogProvider: React.FunctionComponent<DialogProviderProps> = ({
     fullWidth,
     maxWidth,
   } = options;
-
-  const html = {
-    __html: message || '',
-  };
 
   const classes = useStyles(options);
   const showActions = !(hideOk && hideCancel);
@@ -112,76 +108,80 @@ export const DialogProvider: React.FunctionComponent<DialogProviderProps> = ({
   }
 
   return (
-    <Box>
-      <DialogContext.Provider value={provider}>
-        {children}
+    <DialogContext.Provider value={provider}>
+      {children}
 
-        <Dialog
-          fullWidth={fullWidth || DEFAULT_FULL_WIDTH}
-          fullScreen={fullScreen || DEFAULT_FULL_SCREEN}
-          maxWidth={maxWidth || DEFAULT_MAX_WIDTH}
-          open={open}
-          aria-labelledby="dialog-title"
-          aria-describedby="dialog-description"
-        >
-          {title && (
-            <DialogTitle id="dialog-title" className={classes.title}>
-              {title}
-            </DialogTitle>
-          )}
-          {message && (
-            <DialogContent className={`${classes.content} ${className}`}>
-              <DialogContentText id="confirm-dialog-description">
-                <span dangerouslySetInnerHTML={html} />
-              </DialogContentText>
-            </DialogContent>
-          )}
-          {element && (
-            <Box className={`${classes.content} ${className}`}>{element}</Box>
-          )}
-          <Divider />
-          {showActions && (
-            <DialogActions>
-              {!hideCancel && (
-                <Button
-                  color={cancelColor || DEFAULT_CANCEL_COLOR}
-                  onClick={closeHandler}
-                >
-                  {cancelText || DEFAULT_CANCEL_TEXT}
-                </Button>
-              )}
-              {!hideOk && (
-                <Button
-                  color={okColor || DEFAULT_OK_COLOR}
-                  onClick={okHandler}
-                  variant="contained"
-                >
-                  {okText || DEFAULT_OK_TEXT}
-                </Button>
-              )}
-            </DialogActions>
-          )}
-        </Dialog>
-      </DialogContext.Provider>
-    </Box>
+      <Dialog
+        fullWidth={fullWidth || DEFAULT_FULL_WIDTH}
+        fullScreen={fullScreen || DEFAULT_FULL_SCREEN}
+        maxWidth={maxWidth || DEFAULT_MAX_WIDTH}
+        open={open}
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-description"
+      >
+        {title && (
+          <DialogTitle
+            id="dialog-title"
+            className={
+              okColor === 'primary'
+                ? classes.titleBackgroundPrimary
+                : okColor === 'secondary'
+                ? classes.titleBackgroundSecondary
+                : classes.titleBackgroundPrimary
+            }
+          >
+            {title}
+          </DialogTitle>
+        )}
+        {message && (
+          <DialogContent className={clsx(classes.content, className)}>
+            <DialogContentText id="confirm-dialog-description">
+              {message}
+            </DialogContentText>
+          </DialogContent>
+        )}
+        {element && (
+          <Box className={clsx(classes.content, className)}>{element}</Box>
+        )}
+        <Divider />
+        {showActions && (
+          <DialogActions>
+            {!hideCancel && (
+              <Button
+                color={cancelColor || DEFAULT_CANCEL_COLOR}
+                onClick={closeHandler}
+              >
+                {cancelText || DEFAULT_CANCEL_TEXT}
+              </Button>
+            )}
+            {!hideOk && (
+              <Button
+                color={okColor || DEFAULT_OK_COLOR}
+                onClick={okHandler}
+                variant="contained"
+              >
+                {okText || DEFAULT_OK_TEXT}
+              </Button>
+            )}
+          </DialogActions>
+        )}
+      </Dialog>
+    </DialogContext.Provider>
   );
 };
 
-const useStyles = makeStyles((theme) =>
-  createStyles({
+const useStyles = makeStyles((theme) => {
+  return createStyles({
     content: {
       minHeight: theme.spacing(30),
     },
-    title: ({ okColor }: DialogOptions) => {
-      const backgroundColor = !okColor
-        ? theme.palette.primary.main
-        : okColor === 'inherit'
-        ? 'inherit'
-        : theme.palette[okColor].main;
-      return {
-        backgroundColor,
-        color: theme.palette.getContrastText(backgroundColor),
-      };
+    titleBackgroundPrimary: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.getContrastText(theme.palette.primary.main),
     },
-  })
-);
+    titleBackgroundSecondary: {
+      backgroundColor: theme.palette.secondary.main,
+      color: theme.palette.getContrastText(theme.palette.secondary.main),
+    },
+  });
+});

--- a/src/components/dialog/dialog-provider.tsx
+++ b/src/components/dialog/dialog-provider.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+} from '@material-ui/core';
+import {
+  DEFAULT_DIALOG_OPTIONS,
+  DialogOptions,
+  AlertOptions,
+  MessageOptions,
+} from '@/types/dialog';
+import { DialogContext } from '@/components/dialog/dialog-context';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+
+const DEFAULT_OK_COLOR = 'primary';
+const DEFAULT_CANCEL_COLOR = 'secondary';
+const DEFAULT_OK_TEXT = 'OK';
+const DEFAULT_CANCEL_TEXT = 'CANCEL';
+const DEFAULT_FULL_SCREEN = false;
+const DEFAULT_FULL_WIDTH = true;
+const DEFAULT_MAX_WIDTH = 'xs';
+
+interface DialogProviderProps {
+  context?: (context: DialogContext) => void;
+}
+
+export const DialogProvider: React.FunctionComponent<DialogProviderProps> = ({
+  context,
+  children,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [options, setOptions] = useState(DEFAULT_DIALOG_OPTIONS);
+  const {
+    className,
+    title,
+    message,
+    element,
+    okColor,
+    cancelColor,
+    hideOk,
+    hideCancel,
+    okText,
+    cancelText,
+    onOk,
+    onCancel,
+    fullScreen,
+    fullWidth,
+    maxWidth,
+  } = options;
+
+  const html = {
+    __html: message || '',
+  };
+
+  const classes = useStyles(options);
+  const showActions = !(hideOk && hideCancel);
+
+  const confirmHandler = (options: DialogOptions): void => {
+    setOptions(options);
+    setOpen(true);
+  };
+
+  const alertHandler = (options: AlertOptions): void => {
+    setOptions({
+      ...options,
+      okColor: options.color,
+      hideOk: true,
+      hideCancel: true,
+    });
+    setOpen(true);
+  };
+
+  const messageHandler = (options: MessageOptions): void => {
+    setOptions({
+      ...options,
+      okColor: options.color,
+      hideCancel: true,
+    });
+    setOpen(true);
+  };
+
+  const okHandler = (): void => {
+    setOpen(false);
+    if (onOk) {
+      onOk();
+    }
+  };
+
+  const closeHandler = (): void => {
+    setOpen(false);
+    if (onCancel) {
+      onCancel();
+    }
+  };
+
+  const provider: DialogContext = {
+    openConfirm: confirmHandler,
+    openAlert: alertHandler,
+    openMessage: messageHandler,
+    close: closeHandler,
+  };
+
+  if (context) {
+    context(provider);
+  }
+
+  return (
+    <Box>
+      <DialogContext.Provider value={provider}>
+        {children}
+
+        <Dialog
+          fullWidth={fullWidth || DEFAULT_FULL_WIDTH}
+          fullScreen={fullScreen || DEFAULT_FULL_SCREEN}
+          maxWidth={maxWidth || DEFAULT_MAX_WIDTH}
+          open={open}
+          aria-labelledby="dialog-title"
+          aria-describedby="dialog-description"
+        >
+          {title && (
+            <DialogTitle id="dialog-title" className={classes.title}>
+              {title}
+            </DialogTitle>
+          )}
+          {message && (
+            <DialogContent className={`${classes.content} ${className}`}>
+              <DialogContentText id="confirm-dialog-description">
+                <span dangerouslySetInnerHTML={html} />
+              </DialogContentText>
+            </DialogContent>
+          )}
+          {element && (
+            <Box className={`${classes.content} ${className}`}>{element}</Box>
+          )}
+          <Divider />
+          {showActions && (
+            <DialogActions>
+              {!hideCancel && (
+                <Button
+                  color={cancelColor || DEFAULT_CANCEL_COLOR}
+                  onClick={closeHandler}
+                >
+                  {cancelText || DEFAULT_CANCEL_TEXT}
+                </Button>
+              )}
+              {!hideOk && (
+                <Button
+                  color={okColor || DEFAULT_OK_COLOR}
+                  onClick={okHandler}
+                  variant="contained"
+                >
+                  {okText || DEFAULT_OK_TEXT}
+                </Button>
+              )}
+            </DialogActions>
+          )}
+        </Dialog>
+      </DialogContext.Provider>
+    </Box>
+  );
+};
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    content: {
+      minHeight: theme.spacing(30),
+    },
+    title: ({ okColor }: DialogOptions) => {
+      const backgroundColor = !okColor
+        ? theme.palette.primary.main
+        : okColor === 'inherit'
+        ? 'inherit'
+        : theme.palette[okColor].main;
+      return {
+        backgroundColor,
+        color: theme.palette.getContrastText(backgroundColor),
+      };
+    },
+  })
+);

--- a/src/components/records-table/table-head-cell.tsx
+++ b/src/components/records-table/table-head-cell.tsx
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/core';
 import { Order } from './table-head';
 import { SvgIconType } from '@/types/elements';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
 
 interface EnhacedTableHeadCellProps extends TableCellProps {
   label: string;
@@ -30,6 +31,7 @@ export default function EnhancedTableHeadCell({
   onTableCellClick,
   ...props
 }: EnhacedTableHeadCellProps): ReactElement {
+  const classes = useStyles();
   return (
     <TableCell {...props}>
       <TableSortLabel
@@ -40,17 +42,12 @@ export default function EnhancedTableHeadCell({
           onTableCellClick(label);
         }}
       >
-        <Box
-          display="flex"
-          alignItems="center"
-          flexWrap="nowrap"
-          alignContent="center"
-        >
-          {Icon && tooltip && (
-            <Tooltip title={tooltip}>
-              <Icon fontSize="small" color="disabled" />
-            </Tooltip>
-          )}
+        {Icon && tooltip && (
+          <Tooltip title={tooltip}>
+            <Icon fontSize="small" color="disabled" className={classes.icon} />
+          </Tooltip>
+        )}
+        <Box display="inline">
           <Typography
             color="inherit"
             variant="caption"
@@ -64,3 +61,11 @@ export default function EnhancedTableHeadCell({
     </TableCell>
   );
 }
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    icon: {
+      marginRight: theme.spacing(1),
+    },
+  })
+);

--- a/src/components/records-table/table.tsx
+++ b/src/components/records-table/table.tsx
@@ -169,11 +169,10 @@ export default function EnhancedTable({
               }
             }
           },
-          title: `Are you sure you want to delete ${primaryKey}?`,
-          okText: 'Yes, delete',
-          okColor: 'secondary',
-          cancelColor: 'primary',
-          cancelText: 'cancel',
+          title: 'Are you sure you want to delete this item?',
+          message: `Item with id ${primaryKey} in model ${modelName}.`,
+          okText: 'YES',
+          cancelText: 'NO',
         });
         break;
       }

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { DialogContext } from '@/components/dialog/dialog-context';
+
+export const useDialog = (): DialogContext => {
+  return useContext(DialogContext);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { CssBaseline } from '@material-ui/core';
 import { theme } from '../styles/theme';
 import store from '../store';
+import { DialogProvider } from '@/components/dialog/dialog-provider';
 
 import '../styles/globals.css';
 
@@ -20,7 +21,9 @@ function App({ Component, pageProps }: AppProps): ReactElement {
             horizontal: 'center',
           }}
         >
-          <Component {...pageProps} />
+          <DialogProvider>
+            <Component {...pageProps} />
+          </DialogProvider>
         </SnackbarProvider>
       </ThemeProvider>
     </Provider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,7 +8,7 @@ import { theme } from '../styles/theme';
 import store from '../store';
 import { DialogProvider } from '@/components/dialog/dialog-provider';
 
-import '../styles/globals.css';
+import '@/styles/globals.css';
 
 function App({ Component, pageProps }: AppProps): ReactElement {
   return (

--- a/src/types/dialog.ts
+++ b/src/types/dialog.ts
@@ -1,0 +1,50 @@
+import { ButtonProps } from '@material-ui/core';
+import { ReactElement } from 'react';
+
+type Color = ButtonProps['color'];
+
+type maxWidth = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
+
+export interface DialogOptions {
+  className?: string;
+  title?: string;
+  message?: string;
+  element?: ReactElement;
+  okColor?: Color;
+  cancelColor?: Color;
+  hideOk?: boolean;
+  hideCancel?: boolean;
+  okText?: string;
+  cancelText?: string;
+  onOk?: () => void;
+  onCancel?: () => void;
+  fullWidth?: boolean;
+  fullScreen?: boolean;
+  maxWidth?: maxWidth;
+}
+
+export const DEFAULT_DIALOG_OPTIONS: DialogOptions = {};
+
+export interface MessageOptions {
+  className?: string;
+  title?: string;
+  message?: string;
+  element?: ReactElement;
+  color?: Color;
+  okText?: string;
+  onOk?: () => void;
+  fullWidth?: boolean;
+  fullScreen?: boolean;
+  maxWidth?: maxWidth;
+}
+
+export interface AlertOptions {
+  className?: string;
+  title?: string;
+  message?: string;
+  element?: ReactElement;
+  color?: Color;
+  fullWidth?: boolean;
+  fullScreen?: boolean;
+  maxWidth?: maxWidth;
+}


### PR DESCRIPTION
## Description

This PR implements a custom `useDialog` hook. The hook is used in the item page and the record table to display confirmation dialogs depending on the different actions.

## Changes
- add useDialog hook
- add DialogProvider
- add DialogContext

## Additional changes
- fix table-head-cell alignment