### PR TITLE
feat: shared layouts

### DIFF
--- a/src/components/placeholders/restricted-resource.tsx
+++ b/src/components/placeholders/restricted-resource.tsx
@@ -29,17 +29,15 @@ interface RestrictedResourceProps {
 export default function RestrictedResource(
   props: PropsWithChildren<RestrictedResourceProps>
 ): ReactElement {
-  const classes = useStyles();
-
-  const router = useRouter();
-
   const { isAllowed, redirectTimer } = useAuth({
     redirectTo: `/home`,
     redirectIfNotAllowed: true,
     redirectTimeout: 10,
   });
-
+  const router = useRouter();
   const [allow, setAllow] = useState(false);
+  const classes = useStyles();
+
   useEffect(() => setAllow(isAllowed), [isAllowed, setAllow]);
 
   const resourceInfo = useMemo<KeyValueMap>(() => {
@@ -106,11 +104,21 @@ const useStyles = makeStyles((theme) =>
       textDecoration: 'underline',
     },
     header: {
-      ...theme.typography.h2,
+      textAlign: 'center',
+      ...theme.typography.h6,
+      [theme.breakpoints.up('sm')]: {
+        ...theme.typography.h4,
+      },
+      [theme.breakpoints.up('md')]: {
+        ...theme.typography.h3,
+      },
     },
     text: {
       color: theme.palette.text.primary,
-      ...theme.typography.h5,
+      ...theme.typography.body1,
+      [theme.breakpoints.up('sm')]: {
+        ...theme.typography.h5,
+      },
     },
     timer: {
       color: 'orangered',

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -1,0 +1,16 @@
+import { NextPage } from 'next';
+import ModelsLayout from './models';
+
+/**
+ * NextPage enhanced with an optional "layout" property.
+ */
+export type PageWithLayout<P = Record<string, unknown>> = NextPage<P> & {
+  layout?: typeof ModelsLayout;
+};
+
+/**
+ * App entry point (_app.tsx) enhanced with a "Component" that supports layouts
+ */
+export type AppWithLayouts<T> = { Component: PageWithLayout } & T;
+
+export { ModelsLayout };

--- a/src/layouts/models/layout.tsx
+++ b/src/layouts/models/layout.tsx
@@ -1,5 +1,6 @@
-import React, { PropsWithChildren, ReactElement, useState } from 'react';
+import React, { PropsWithChildren, ReactElement, useReducer } from 'react';
 import clsx from 'clsx';
+import dynamic from 'next/dynamic';
 
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { Box, Fab, Zoom } from '@material-ui/core';
@@ -7,35 +8,36 @@ import {
   ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon,
 } from '@material-ui/icons';
-
-import useAuth from '@/hooks/useAuth';
-import { AppRoutes } from '@/types/routes';
-
 import RestrictedResource from '@/components/placeholders/restricted-resource';
-import Toolbar from './toolbar';
-import Navigation from './navigation';
 
-interface ModelsDesktopLayoutProps {
-  brand: string;
-  routes: AppRoutes;
+import appRoutes, { AppRoutes } from '@/build/routes';
+import useAuth from '@/hooks/useAuth';
+import Toolbar from './toolbar';
+const Navigation = dynamic(() => import('./navigation'), { ssr: false });
+
+export interface ModelsDesktopLayoutProps {
+  brand?: string;
+  routes?: AppRoutes;
 }
 
-export default function ModelsDashboard({
+export default function ModelsLayout({
   brand,
   routes,
   children,
 }: PropsWithChildren<ModelsDesktopLayoutProps>): ReactElement {
   const classes = useStyles();
-  const [drawerOpen, setDrawerOpen] = useState(true);
-  const toggleDrawer = (): void => setDrawerOpen((state) => !state);
+  const [drawerOpen, toggleDrawer] = useReducer<(state: boolean) => boolean>(
+    (state) => !state,
+    true
+  );
   const { auth } = useAuth();
 
   return (
     <div className={classes.root}>
-      <Toolbar brand={brand}>
+      <Toolbar brand={brand ?? 'Zendro'}>
         <Zoom in={true} timeout={500}>
           <Box>
-            <Fab size="medium" color="primary" onClick={toggleDrawer}>
+            <Fab size="medium" onClick={toggleDrawer}>
               {drawerOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
             </Fab>
           </Box>
@@ -46,8 +48,7 @@ export default function ModelsDashboard({
         <Navigation
           className={drawerOpen ? classes.drawerOpen : classes.drawerClosed}
           permissions={auth.user?.permissions}
-          component="nav"
-          routes={routes}
+          routes={routes ?? ((appRoutes as unknown) as AppRoutes)}
         />
         <main
           className={clsx(classes.mainContent, {

--- a/src/layouts/models/layout.tsx
+++ b/src/layouts/models/layout.tsx
@@ -1,9 +1,14 @@
-import React, { PropsWithChildren, ReactElement, useReducer } from 'react';
+import React, {
+  PropsWithChildren,
+  ReactElement,
+  useEffect,
+  useState,
+} from 'react';
 import clsx from 'clsx';
 import dynamic from 'next/dynamic';
 
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
-import { Box, Fab, Zoom } from '@material-ui/core';
+import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles';
+import { Box, Fab, useMediaQuery, Zoom } from '@material-ui/core';
 import {
   ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon,
@@ -25,19 +30,23 @@ export default function ModelsLayout({
   routes,
   children,
 }: PropsWithChildren<ModelsDesktopLayoutProps>): ReactElement {
-  const classes = useStyles();
-  const [drawerOpen, toggleDrawer] = useReducer<(state: boolean) => boolean>(
-    (state) => !state,
-    true
-  );
   const { auth } = useAuth();
+  const classes = useStyles();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const theme = useTheme();
+
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
+  useEffect(() => setDrawerOpen(isLargeScreen), [isLargeScreen]);
 
   return (
     <div className={classes.root}>
-      <Toolbar brand={brand ?? 'Zendro'}>
+      <Toolbar brand={brand ?? ''}>
         <Zoom in={true} timeout={500}>
           <Box>
-            <Fab size="medium" onClick={toggleDrawer}>
+            <Fab
+              size={isLargeScreen ? 'medium' : 'small'}
+              onClick={() => setDrawerOpen((state) => !state)}
+            >
               {drawerOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
             </Fab>
           </Box>
@@ -46,7 +55,9 @@ export default function ModelsLayout({
 
       <div className={classes.mainContainer}>
         <Navigation
-          className={drawerOpen ? classes.drawerOpen : classes.drawerClosed}
+          className={clsx(classes.drawer, {
+            [classes.drawerClosed]: !drawerOpen,
+          })}
           permissions={auth.user?.permissions}
           routes={routes ?? ((appRoutes as unknown) as AppRoutes)}
         />
@@ -62,7 +73,7 @@ export default function ModelsLayout({
   );
 }
 
-const useStyles = makeStyles((theme: Theme) => {
+const useStyles = makeStyles((theme) => {
   return createStyles({
     root: {
       height: '100%',
@@ -72,8 +83,15 @@ const useStyles = makeStyles((theme: Theme) => {
       display: 'flex',
       height: `calc(100% - ${theme.spacing(18)})`,
     },
-    drawerOpen: {
-      width: '18rem',
+    drawer: {
+      width: '100%',
+      transition: theme.transitions.create(['width'], {
+        duration: theme.transitions.duration.standard,
+        easing: theme.transitions.easing.sharp,
+      }),
+      [theme.breakpoints.up('md')]: {
+        width: theme.spacing(72),
+      },
     },
     drawerClosed: {
       width: 0,
@@ -87,11 +105,14 @@ const useStyles = makeStyles((theme: Theme) => {
       }),
     },
     mainContentShift: {
-      width: `calc(100% - 18rem)`,
-      transition: theme.transitions.create(['width'], {
-        duration: theme.transitions.duration.standard,
-        easing: theme.transitions.easing.sharp,
-      }),
+      width: 0,
+      [theme.breakpoints.up('md')]: {
+        width: `calc(100% - ${theme.spacing(72)})`,
+        transition: theme.transitions.create(['width'], {
+          duration: theme.transitions.duration.standard,
+          easing: theme.transitions.easing.sharp,
+        }),
+      },
     },
   });
 });

--- a/src/layouts/models/layout.tsx
+++ b/src/layouts/models/layout.tsx
@@ -43,10 +43,7 @@ export default function ModelsLayout({
       <Toolbar brand={brand ?? ''}>
         <Zoom in={true} timeout={500}>
           <Box>
-            <Fab
-              size={isLargeScreen ? 'medium' : 'small'}
-              onClick={() => setDrawerOpen((state) => !state)}
-            >
+            <Fab size="small" onClick={() => setDrawerOpen((state) => !state)}>
               {drawerOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
             </Fab>
           </Box>

--- a/src/layouts/models/navigation.tsx
+++ b/src/layouts/models/navigation.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import clsx from 'clsx';
 
 import { Box, createStyles, makeStyles } from '@material-ui/core';
 import {
@@ -10,18 +11,15 @@ import {
 import { NavGroup, NavLink } from '@/components/navigation';
 import { AuthPermissions } from '@/types/auth';
 import { AppRoutes } from '@/types/routes';
-import clsx from 'clsx';
 
 interface AppDrawerProps {
   className?: string;
-  component?: React.ElementType;
   permissions?: AuthPermissions;
   routes: AppRoutes;
 }
 
 export default function Navigation({
   className,
-  component,
   permissions,
   routes,
 }: AppDrawerProps): ReactElement {
@@ -43,10 +41,7 @@ export default function Navigation({
   };
 
   return (
-    <Box
-      component={component}
-      className={clsx(classes.drawer, className ?? '')}
-    >
+    <Box component="nav" className={clsx(classes.drawer, className ?? '')}>
       <NavLink
         className={classes.homeLink}
         href="/home"

--- a/src/layouts/models/navigation.tsx
+++ b/src/layouts/models/navigation.tsx
@@ -96,10 +96,6 @@ const useStyles = makeStyles((theme) => {
       overflow: 'hidden',
       borderRight: '1px solid',
       borderRightColor: theme.palette.grey[300],
-      transition: theme.transitions.create(['width'], {
-        duration: theme.transitions.duration.standard,
-        easing: theme.transitions.easing.sharp,
-      }),
     },
     homeLink: {
       display: 'flex',
@@ -108,7 +104,7 @@ const useStyles = makeStyles((theme) => {
       paddingBottom: theme.spacing(3),
     },
     linkText: {
-      paddingLeft: theme.spacing(8),
+      paddingLeft: theme.spacing(18),
     },
   });
 });

--- a/src/layouts/models/toolbar.tsx
+++ b/src/layouts/models/toolbar.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren, ReactElement } from 'react';
 import Link from 'next/link';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
-import { Typography } from '@material-ui/core';
 import LanguageSwitcher from '@/components/toolbar/lang-switcher';
 import LogoutButton from '@/components/toolbar/logout-button';
 
@@ -20,9 +19,7 @@ export default function Toolbar({
       {props.children}
 
       <Link href="/" passHref>
-        <Typography marginLeft="1rem" variant="h4" component="a" noWrap>
-          {brand}
-        </Typography>
+        <a className={classes.brand}>{brand}</a>
       </Link>
 
       <div className={classes.menus}>
@@ -44,6 +41,13 @@ const useStyles = makeStyles((theme) => {
       color: theme.palette.getContrastText(theme.palette.primary.main),
       backgroundColor: theme.palette.primary.main,
       boxShadow: theme.shadows[3],
+    },
+    brand: {
+      marginLeft: theme.spacing(4),
+      ...theme.typography.h5,
+      [theme.breakpoints.up('sm')]: {
+        ...theme.typography.h4,
+      },
     },
     menus: {
       marginLeft: 'auto',

--- a/src/pages/[model]/index.tsx
+++ b/src/pages/[model]/index.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
-import {
-  getStaticModel,
-  getStaticRoutes,
-  getStaticModelPaths,
-} from '@/utils/static';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { getStaticModel, getStaticModelPaths } from '@/utils/static';
 import { getAttributeList } from '@/utils/models';
 import {
   queryRecord,
@@ -12,13 +8,8 @@ import {
   queryModelTableRecordsCount,
 } from '@/utils/queries';
 import { PathParams } from '@/types/models';
-import { AppRoutes } from '@/types/routes';
-import ModelsLayout from '@/layouts/models';
+import { ModelsLayout, PageWithLayout } from '@/layouts';
 import EnhancedTable, { EnhancedTableProps } from '@/components/records-table';
-
-interface ModelProps extends EnhancedTableProps {
-  routes: AppRoutes;
-}
 
 export const getStaticPaths: GetStaticPaths<PathParams> = async () => {
   const paths = await getStaticModelPaths();
@@ -28,13 +19,13 @@ export const getStaticPaths: GetStaticPaths<PathParams> = async () => {
   };
 };
 
-export const getStaticProps: GetStaticProps<ModelProps, PathParams> = async (
-  context
-) => {
+export const getStaticProps: GetStaticProps<
+  EnhancedTableProps,
+  PathParams
+> = async (context) => {
   const params = context.params as PathParams;
 
   const modelName = params.model;
-  const routes = await getStaticRoutes();
   const dataModel = await getStaticModel(modelName);
 
   const attributes = getAttributeList(dataModel);
@@ -52,26 +43,23 @@ export const getStaticProps: GetStaticProps<ModelProps, PathParams> = async (
         delete: _delete,
         count,
       },
-      routes,
       key: modelName,
     },
   };
 };
 
-const Model: NextPage<ModelProps> = ({
+const Model: PageWithLayout<EnhancedTableProps> = ({
   modelName,
   attributes,
   requests,
-  routes,
 }) => {
   return (
-    <ModelsLayout brand="Zendro" routes={routes}>
-      <EnhancedTable
-        modelName={modelName}
-        attributes={attributes}
-        requests={requests}
-      />
-    </ModelsLayout>
+    <EnhancedTable
+      modelName={modelName}
+      attributes={attributes}
+      requests={requests}
+    />
   );
 };
+Model.layout = ModelsLayout;
 export default Model;

--- a/src/pages/[model]/item.tsx
+++ b/src/pages/[model]/item.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useReducer, useState } from 'react';
 import { capitalize } from 'inflection';
-import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
+import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 
@@ -28,24 +28,19 @@ import {
   PathParams,
 } from '@/types/models';
 import { RawQuery, ComposedQuery } from '@/types/queries';
-import { AppRoutes } from '@/types/routes';
 
 import { getAttributeList, parseAssociations } from '@/utils/models';
 import { queryRecord } from '@/utils/queries';
 import { requestOne } from '@/utils/requests';
-import {
-  getStaticModelPaths,
-  getStaticRoutes,
-  getStaticModel,
-} from '@/utils/static';
+import { getStaticModelPaths, getStaticModel } from '@/utils/static';
 import { isNullorUndefined } from '@/utils/validation';
 import { isNullorEmpty } from '@/utils/validation';
+import { PageWithLayout } from '@/layouts';
 
 interface RecordProps {
   associations: ParsedAssociation[];
   attributes: ParsedAttribute[];
   modelName: string;
-  routes: AppRoutes;
   requests: ReturnType<typeof queryRecord>;
 }
 
@@ -63,7 +58,6 @@ export const getStaticProps: GetStaticProps<RecordProps, PathParams> = async (
   const params = context.params as PathParams;
 
   const modelName = params.model;
-  const routes = await getStaticRoutes();
   const dataModel = await getStaticModel(modelName);
 
   const attributes = getAttributeList(dataModel, { excludeForeignKeys: true });
@@ -76,7 +70,6 @@ export const getStaticProps: GetStaticProps<RecordProps, PathParams> = async (
       modelName,
       attributes,
       associations,
-      routes,
       requests,
     },
   };
@@ -189,11 +182,10 @@ function composeReadOneRequest(
   }
 }
 
-const Record: NextPage<RecordProps> = ({
+const Record: PageWithLayout<RecordProps> = ({
   associations,
   attributes,
   modelName,
-  routes,
   requests,
 }) => {
   const { auth } = useAuth();
@@ -421,50 +413,46 @@ const Record: NextPage<RecordProps> = ({
   };
 
   return (
-    <ModelsLayout brand="Zendro" routes={routes}>
-      <TabContext value={tabIndex}>
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <TabList
-            onChange={handleOnTabChange}
-            aria-label="lab API tabs example"
-          >
-            <Tab label="Attributes" value="attributes" />
-            <Tab
-              label="Associations"
-              value="associations"
-              disabled={associations.length === 0}
-            />
-          </TabList>
-        </Box>
-        <TabPanel value="attributes">
-          <AttributesForm
-            attributes={formAttributes}
-            className={classes.form}
-            disabled={formView === 'read'}
-            formId={formId}
-            onChange={handleOnChange}
-            onSubmit={handleOnSubmit(formView)}
-            title={{
-              prefix: capitalize(formView),
-              main: modelName,
-            }}
-            actions={
-              <FormActions
-                permissions={auth.user?.permissions[modelName] ?? []}
-                view={formView}
-                formId={formId}
-                onAction={handleOnFormAction}
-              />
-            }
+    <TabContext value={tabIndex}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <TabList onChange={handleOnTabChange} aria-label="lab API tabs example">
+          <Tab label="Attributes" value="attributes" />
+          <Tab
+            label="Associations"
+            value="associations"
+            disabled={associations.length === 0}
           />
-        </TabPanel>
-        <TabPanel value="associations">
-          <AssociationList modelName={modelName} associations={associations} />
-        </TabPanel>
-      </TabContext>
-    </ModelsLayout>
+        </TabList>
+      </Box>
+      <TabPanel value="attributes">
+        <AttributesForm
+          attributes={formAttributes}
+          className={classes.form}
+          disabled={formView === 'read'}
+          formId={formId}
+          onChange={handleOnChange}
+          onSubmit={handleOnSubmit(formView)}
+          title={{
+            prefix: capitalize(formView),
+            main: modelName,
+          }}
+          actions={
+            <FormActions
+              permissions={auth.user?.permissions[modelName] ?? []}
+              view={formView}
+              formId={formId}
+              onAction={handleOnFormAction}
+            />
+          }
+        />
+      </TabPanel>
+      <TabPanel value="associations">
+        <AssociationList modelName={modelName} associations={associations} />
+      </TabPanel>
+    </TabContext>
   );
 };
+Record.layout = ModelsLayout;
 export default Record;
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,11 +5,13 @@ import { AppProps } from 'next/app';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CssBaseline } from '@material-ui/core';
 import { DialogProvider } from '@/hooks/useDialog';
+import { AppWithLayouts } from '@/layouts';
 import store from '@/store';
 import { theme } from '@/styles/theme';
 import '@/styles/globals.css';
 
-function App({ Component, pageProps }: AppProps): ReactElement {
+function App({ Component, pageProps }: AppWithLayouts<AppProps>): ReactElement {
+  const Layout = Component.layout ?? (({ children }) => <>{children}</>);
   return (
     <Provider store={store}>
       <ThemeProvider theme={theme}>
@@ -21,7 +23,9 @@ function App({ Component, pageProps }: AppProps): ReactElement {
           }}
         >
           <DialogProvider>
-            <Component {...pageProps} />
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
           </DialogProvider>
         </SnackbarProvider>
       </ThemeProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ function App({ Component, pageProps }: AppWithLayouts<AppProps>): ReactElement {
           }}
         >
           <DialogProvider>
-            <Layout>
+            <Layout brand="Zendro">
               <Component {...pageProps} />
             </Layout>
           </DialogProvider>


### PR DESCRIPTION
## Description

This PR implements a common layout feature that allows individual pages to share a single layout component. 

## Features
- Pages can select a shared layout by importing it from the `src/layouts` folder.
- Pages that share a layout should preserve the current layout state for all its children.
- The models layout has been made slightly more responsive to various screen sizes.
- The models layout navigation uses the `custom/routes.json` file if it exists.
- The models layout navigation component is only evaluated at runtime (via `dynamic`). 

## Resources

https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/