### PR TITLE
hotfix: action routes

### DIFF
--- a/src/components/records-table/table.tsx
+++ b/src/components/records-table/table.tsx
@@ -35,6 +35,7 @@ import {
   useZendroClient,
 } from '@/hooks';
 import { ExtendedClientError } from '@/types/errors';
+import { ModelUrlQuery } from '@/types/routes';
 
 export interface EnhancedTableProps {
   modelName: string;
@@ -124,6 +125,8 @@ export default function EnhancedTable({
   const zendro = useZendroClient();
   const { auth } = useAuth();
 
+  const query = router.query as ModelUrlQuery;
+
   /* HANDLERS */
   const handleSetOrder = (field: string): void => {
     const isAsc =
@@ -138,11 +141,11 @@ export default function EnhancedTable({
   };
 
   const handleOnRead = (primaryKey: string | number): void => {
-    router.push(`/models/${modelName}/details?id=${primaryKey}`);
+    router.push(`/${query.group}/${modelName}/details?id=${primaryKey}`);
   };
 
   const handleOnUpdate = (primaryKey: string | number): void => {
-    router.push(`/models/${modelName}/edit?id=${primaryKey}`);
+    router.push(`/${query.group}/${modelName}/edit?id=${primaryKey}`);
   };
 
   const handleOnDelete = (primaryKey: string | number): void => {

--- a/src/pages/[group]/[model]/details.tsx
+++ b/src/pages/[group]/[model]/details.tsx
@@ -9,7 +9,7 @@ import { TabContext, TabList, TabPanel } from '@material-ui/lab';
 import AttributesForm, { ActionHandler } from '@/components/attributes-form';
 import AssociationList from '@/components/association-list';
 
-import { useToastNotification, useZendroClient } from '@/hooks';
+import { useModel, useToastNotification, useZendroClient } from '@/hooks';
 import { ModelsLayout, PageWithLayout } from '@/layouts';
 
 import { DataRecord, ParsedAssociation, ParsedAttribute } from '@/types/models';
@@ -65,6 +65,7 @@ const Record: PageWithLayout<RecordProps> = ({
   modelName,
   requests,
 }) => {
+  const model = useModel();
   const router = useRouter();
   const classes = useStyles();
   const { showSnackbar } = useToastNotification();
@@ -110,14 +111,14 @@ const Record: PageWithLayout<RecordProps> = ({
    * Exit the form and go back to the model table page.
    */
   const handleOnCancel: ActionHandler = () => {
-    router.push(`/models/${modelName}`);
+    router.push(`/${urlQuery.group}/${modelName}`);
   };
 
   /**
    * Navigate to the record details page.
    */
   const handleOnUpdate: ActionHandler = () => {
-    router.push(`/models/${modelName}/edit?id=${urlQuery.id}`);
+    router.push(`/${urlQuery.group}/${modelName}/edit?id=${urlQuery.id}`);
   };
 
   /**
@@ -164,7 +165,7 @@ const Record: PageWithLayout<RecordProps> = ({
           modelName={modelName}
           actions={{
             cancel: handleOnCancel,
-            update: handleOnUpdate,
+            update: model.permissions.update ? handleOnUpdate : undefined,
             reload: handleOnReload,
           }}
         />

--- a/src/pages/[group]/[model]/edit.tsx
+++ b/src/pages/[group]/[model]/edit.tsx
@@ -12,7 +12,12 @@ import AttributesForm, {
 } from '@/components/attributes-form';
 import AssociationList from '@/components/association-list';
 
-import { useDialog, useToastNotification, useZendroClient } from '@/hooks';
+import {
+  useDialog,
+  useModel,
+  useToastNotification,
+  useZendroClient,
+} from '@/hooks';
 import { ModelsLayout, PageWithLayout } from '@/layouts';
 
 import { ExtendedClientError } from '@/types/errors';
@@ -71,6 +76,7 @@ const Record: PageWithLayout<RecordProps> = ({
   requests,
 }) => {
   const dialog = useDialog();
+  const { permissions } = useModel();
   const router = useRouter();
   const classes = useStyles();
   const { showSnackbar } = useToastNotification();
@@ -133,11 +139,11 @@ const Record: PageWithLayout<RecordProps> = ({
         message: 'Do you want to leave anyway?',
         okText: 'Yes',
         cancelText: 'No',
-        onOk: () => router.push(`/models/${modelName}`),
+        onOk: () => router.push(`/${urlQuery.group}/${modelName}`),
       });
     }
 
-    router.push(`/models/${modelName}`);
+    router.push(`/${urlQuery.group}/${modelName}`);
   };
 
   /**
@@ -158,7 +164,7 @@ const Record: PageWithLayout<RecordProps> = ({
           await zendro.request(_delete.query, {
             [primaryKey]: idValue,
           });
-          router.push(`/${modelName}`);
+          router.push(`/${urlQuery.group}/${modelName}`);
         } catch (error) {
           showSnackbar('Error in request to server', 'error', error);
         }
@@ -170,7 +176,7 @@ const Record: PageWithLayout<RecordProps> = ({
    * Navigate to the record details page.
    */
   const handleOnDetails: ActionHandler = () => {
-    router.push(`/models/${modelName}/details?id=${urlQuery.id}`);
+    router.push(`/${urlQuery.group}/${modelName}/details?id=${urlQuery.id}`);
   };
 
   /**
@@ -220,7 +226,7 @@ const Record: PageWithLayout<RecordProps> = ({
           [requests.read.resolver]: response[requests.update.resolver],
         });
 
-        router.push(`/${modelName}`);
+        router.push(`/${urlQuery.group}/${modelName}`);
       } catch (error) {
         const clientError = error as ExtendedClientError<
           Record<string, DataRecord>
@@ -314,7 +320,7 @@ const Record: PageWithLayout<RecordProps> = ({
           actions={{
             cancel: handleOnCancel,
             delete: handleOnDelete,
-            read: handleOnDetails,
+            read: permissions.read ? handleOnDetails : undefined,
             reload: handleOnReload,
             submit: handleOnSubmit,
           }}

--- a/src/pages/[group]/[model]/new.tsx
+++ b/src/pages/[group]/[model]/new.tsx
@@ -71,6 +71,7 @@ const Record: PageWithLayout<RecordProps> = ({
   const classes = useStyles();
   const { showSnackbar } = useToastNotification();
   const zendro = useZendroClient();
+  const urlQuery = router.query as ModelUrlQuery;
 
   /* STATE */
 
@@ -91,11 +92,11 @@ const Record: PageWithLayout<RecordProps> = ({
         message: 'Do you want to leave anyway?',
         okText: 'Yes',
         cancelText: 'No',
-        onOk: () => router.push(`/models/${modelName}`),
+        onOk: () => router.push(`/${urlQuery.group}/${modelName}`),
       });
     }
 
-    router.push(`/models/${modelName}`);
+    router.push(`/${urlQuery.group}/${modelName}`);
   };
 
   /**
@@ -115,7 +116,7 @@ const Record: PageWithLayout<RecordProps> = ({
           dataRecord
         );
 
-        router.push(`/${modelName}`);
+        router.push(`/${urlQuery.group}/${modelName}`);
       } catch (error) {
         setAjvErrors(undefined);
         const clientError = error as ExtendedClientError<

--- a/src/types/acl.ts
+++ b/src/types/acl.ts
@@ -1,1 +1,5 @@
 export type AclPermission = 'create' | 'read' | 'update' | 'delete' | '*';
+
+export type ParsedPermissions = {
+  [key in Exclude<AclPermission, '*'>]: boolean;
+};


### PR DESCRIPTION
## Description

This PR fixes  `records-table` and `record-form` actions to: 
- Use the correct route, depending on their assigned model `group`.
- Show details/edit actions only if the user has those permissions.

To apply this hotfix, the `useModel` hook has been temporarily enhanced to also compute model `permissions`. The hook does not assume it is called from within a `/[group]/[model]` route. A future solution might change that.