### PR TITLE
feat: theme colors and navigation UX

### DIFF
--- a/src/components/navigation/breadcrumbs.tsx
+++ b/src/components/navigation/breadcrumbs.tsx
@@ -57,13 +57,10 @@ const useStyles = makeStyles((theme) =>
       alignItems: 'center',
       fontSize: theme.spacing(4),
       textTransform: 'uppercase',
-      '&:hover': {
-        fontWeight: 'bold',
-      },
     },
     link: {
+      color: theme.palette.primary.main,
       '&:hover': {
-        color: theme.palette.primary.main,
         textDecoration: 'underline',
       },
     },

--- a/src/components/toolbar/lang-switcher.tsx
+++ b/src/components/toolbar/lang-switcher.tsx
@@ -3,15 +3,16 @@ import { useRef, useState } from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import {
   IconButton,
-  Tooltip,
+  IconButtonProps,
   Menu,
   MenuItem,
+  Tooltip,
   Typography,
 } from '@material-ui/core';
 import Translate from '@material-ui/icons/TranslateRounded';
 import i18n from '../../i18n';
 
-export default function LanguageSwitcher(): ReactElement {
+export default function LanguageSwitcher(props: IconButtonProps): ReactElement {
   const classes = useStyles();
 
   const translations = useRef([
@@ -46,6 +47,7 @@ export default function LanguageSwitcher(): ReactElement {
       {/* Translate.icon */}
       <Tooltip title="Change language">
         <IconButton
+          {...props}
           id={'MainPanel-iconButton-translate'}
           color="inherit"
           onClick={handleTranslationIconClick}
@@ -60,6 +62,8 @@ export default function LanguageSwitcher(): ReactElement {
         keepMounted
         open={Boolean(translationAnchorEl)}
         onClose={handleTranslationMenuClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       >
         {translations.current.map((translation, index) => (
           <MenuItem

--- a/src/components/toolbar/logout-button.tsx
+++ b/src/components/toolbar/logout-button.tsx
@@ -2,9 +2,9 @@ import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'react-i18next';
 import useAuth from '@/hooks/useAuth';
-import { Button } from '@material-ui/core';
+import { Button, ButtonProps } from '@material-ui/core';
 
-export default function LogoutButton(): ReactElement {
+export default function LogoutButton(props: ButtonProps): ReactElement {
   const { logout } = useAuth();
   const { t } = useTranslation();
   const router = useRouter();
@@ -15,7 +15,7 @@ export default function LogoutButton(): ReactElement {
   };
 
   return (
-    <Button color="inherit" onClick={handleLogoutButtonClick}>
+    <Button onClick={handleLogoutButtonClick} {...props}>
       {t('toolBar.logout')}
     </Button>
   );

--- a/src/layouts/models/layout.tsx
+++ b/src/layouts/models/layout.tsx
@@ -3,6 +3,7 @@ import React, {
   PropsWithChildren,
   ReactElement,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 
@@ -16,6 +17,7 @@ import { createStyles, makeStyles, useTheme } from '@material-ui/core/styles';
 import appRoutes from '@/build/routes.preval';
 import { AppRoutes } from '@/types/routes';
 import Toolbar from './toolbar';
+import { useRouter } from 'next/router';
 const Models = dynamic(() => import('./main'), { ssr: false });
 
 export interface ModelsDesktopLayoutProps {
@@ -29,11 +31,29 @@ export default function ModelsLayout({
   children,
 }: PropsWithChildren<ModelsDesktopLayoutProps>): ReactElement {
   const classes = useStyles();
+  const router = useRouter();
+  const routePath = useRef(router.asPath);
   const [showNav, setShowNav] = useState(false);
   const theme = useTheme();
-
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
-  useEffect(() => setShowNav(isLargeScreen), [isLargeScreen]);
+
+  useEffect(
+    function hideNavOnSmallScreen() {
+      setShowNav(isLargeScreen);
+    },
+    [isLargeScreen, setShowNav]
+  );
+
+  useEffect(
+    function hideNavOnRouteChange() {
+      const routeHasChanged = routePath.current !== router.asPath;
+      if (routeHasChanged && !isLargeScreen) {
+        routePath.current = router.asPath;
+        setShowNav(false);
+      }
+    },
+    [routePath, isLargeScreen, router]
+  );
 
   return (
     <div className={classes.root}>

--- a/src/layouts/models/main.tsx
+++ b/src/layouts/models/main.tsx
@@ -105,9 +105,10 @@ export default function Models({
 const useStyles = makeStyles((theme) => {
   return createStyles({
     breadcrumbs: {
-      alignItems: 'center',
-      backgroundColor: theme.palette.action.hover,
       display: 'flex',
+      alignItems: 'center',
+      flexShrink: 0,
+      backgroundColor: theme.palette.action.hover,
       height: theme.spacing(14),
       padding: theme.spacing(0, 4),
     },

--- a/src/layouts/models/navigation.tsx
+++ b/src/layouts/models/navigation.tsx
@@ -2,7 +2,8 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
 
-import { Box, createStyles, makeStyles } from '@material-ui/core';
+import { Box } from '@material-ui/core';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
 import {
   BubbleChart as ModelsIcon,
   Home as HomeIcon,
@@ -105,14 +106,11 @@ const useStyles = makeStyles((theme) => {
         paddingLeft: theme.spacing(18),
       },
       '& a:hover:not(.active), ul > button:hover': {
-        backgroundColor: theme.palette.action.focus,
-        '& .MuiTypography-root': {
-          fontWeight: 'bold',
-        },
+        backgroundColor: theme.palette.primary.light,
       },
       '& a.active': {
-        color: theme.palette.getContrastText(theme.palette.action.active),
-        backgroundColor: theme.palette.action.active,
+        color: theme.palette.getContrastText(theme.palette.primary.main),
+        backgroundColor: theme.palette.primary.main,
         '& .MuiTypography-root': {
           fontWeight: 'bold',
         },

--- a/src/layouts/models/toolbar.tsx
+++ b/src/layouts/models/toolbar.tsx
@@ -15,7 +15,7 @@ export default function Toolbar({
   const classes = useStyles();
 
   return (
-    <header className={classes.root}>
+    <header className={classes.header}>
       {props.children}
 
       <Link href="/" passHref>
@@ -23,8 +23,8 @@ export default function Toolbar({
       </Link>
 
       <div className={classes.menus}>
-        <LanguageSwitcher />
-        <LogoutButton />
+        <LanguageSwitcher className={classes.langButton} />
+        <LogoutButton color="inherit" disableElevation />
       </div>
     </header>
   );
@@ -32,7 +32,14 @@ export default function Toolbar({
 
 const useStyles = makeStyles((theme) => {
   return createStyles({
-    root: {
+    brand: {
+      marginLeft: theme.spacing(4),
+      ...theme.typography.h5,
+      [theme.breakpoints.up('sm')]: {
+        ...theme.typography.h4,
+      },
+    },
+    header: {
       display: 'flex',
       alignItems: 'center',
       width: '100%',
@@ -42,12 +49,8 @@ const useStyles = makeStyles((theme) => {
       backgroundColor: theme.palette.primary.main,
       boxShadow: theme.shadows[3],
     },
-    brand: {
-      marginLeft: theme.spacing(4),
-      ...theme.typography.h5,
-      [theme.breakpoints.up('sm')]: {
-        ...theme.typography.h4,
-      },
+    langButton: {
+      marginRight: theme.spacing(3),
     },
     menus: {
       marginLeft: 'auto',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,8 +1,50 @@
-import { createMuiTheme } from '@material-ui/core';
+import { createMuiTheme } from '@material-ui/core/styles';
 
 const defaultTheme = createMuiTheme();
+
+const blue = {
+  50: '#f0f4f8',
+  100: '#d9e2ec',
+  200: '#bcccdc',
+  300: '#9fb3c8',
+  400: '#829ab1',
+  500: '#627d98',
+  600: '#486581',
+  700: '#334e68',
+  800: '#243b53',
+  900: '#102a43',
+};
+
+const red = {
+  50: '#ffe3e3',
+  100: '#ffdbdb',
+  200: '#ff9b9b',
+  300: '#f86a6a',
+  400: '#ef4e4e',
+  500: '#e12d39',
+  600: '#cf1124',
+  700: '#ab091e',
+  800: '#8a041a',
+  900: '#610316',
+};
 
 export const theme = createMuiTheme({
   spacing: (value: number) => defaultTheme.typography.pxToRem(value / 0.25),
   // spacing: (value: number) => `${0.25 * value}rem`,
+  palette: {
+    primary: {
+      light: blue[100],
+      main: blue[600],
+      dark: blue[700],
+    },
+    secondary: {
+      light: red[200],
+      main: red[600],
+      dark: red[700],
+    },
+  },
+  color: {
+    blue,
+    red,
+  },
 });

--- a/src/zendro/record-form/form.tsx
+++ b/src/zendro/record-form/form.tsx
@@ -174,7 +174,7 @@ export default function AttributesForm({
         <div className={clsx(classes.actions, classes.leftActions)}>
           {actions?.cancel && (
             <ActionButton
-              color="secondary"
+              className={classes.actionSecondary}
               form={formId}
               onClick={handleOnAction({
                 action: 'cancel',
@@ -187,7 +187,7 @@ export default function AttributesForm({
 
           {actions?.read && (
             <ActionButton
-              color="primary"
+              className={classes.actionSupport}
               form={formId}
               icon={ReadIcon}
               onClick={handleOnAction({
@@ -200,7 +200,7 @@ export default function AttributesForm({
 
           {actions?.update && (
             <ActionButton
-              color="primary"
+              className={classes.actionSupport}
               form={formId}
               icon={EditIcon}
               onClick={handleOnAction({
@@ -215,7 +215,7 @@ export default function AttributesForm({
         <div className={clsx(classes.actions, classes.rightActions)}>
           {actions?.delete && (
             <ActionButton
-              color="secondary"
+              className={classes.actionSecondary}
               form={formId}
               icon={DeleteIcon}
               onClick={handleOnAction({
@@ -228,7 +228,7 @@ export default function AttributesForm({
 
           {actions?.reload && (
             <ActionButton
-              color="primary"
+              className={classes.actionSupport}
               form={formId}
               icon={Reload}
               tooltip="Reload data"
@@ -241,7 +241,7 @@ export default function AttributesForm({
 
           {actions?.submit && (
             <ActionButton
-              color="primary"
+              className={classes.actionPrimary}
               form={formId}
               icon={SaveIcon}
               tooltip="Submit changes"
@@ -346,6 +346,19 @@ const useStyles = makeStyles((theme) =>
         width: theme.spacing(14),
         height: theme.spacing(14),
       },
+    },
+    actionPrimary: {
+      color: theme.palette.grey[100],
+      backgroundColor: theme.palette.primary.main,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+    actionSecondary: {
+      color: theme.palette.secondary.main,
+    },
+    actionSupport: {
+      color: theme.palette.primary.main,
     },
   })
 );

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -1,0 +1,21 @@
+import { Color as MuiColor } from '@material-ui/core';
+import {
+  Theme as MuiTheme,
+  ThemeOptions as MuiThemeOptions,
+} from '@material-ui/core/styles';
+
+type Colors = Record<
+  'blue' | 'red',
+  Omit<MuiColor, 'A100' | 'A200' | 'A400' | 'A700'>
+>;
+
+declare module '@material-ui/core/styles' {
+  interface Theme extends MuiTheme {
+    color: Colors;
+  }
+
+  // allow configuration using `createMuiTheme`
+  interface ThemeOptions extends MuiThemeOptions {
+    color?: Partial<Colors>;
+  }
+}


### PR DESCRIPTION
## Summary

This PR makes adjustments to the color palette and slightly improves the navigation feedback to user interaction.

## Changes
- Fix the breadcrumbs navigation shrinking in large forms.
- Refactor the logout and language-switcher buttons to inherit from (and pass down) properties of their main internal MUI components.
- Display the language selection menu under the switcher button.
- Tone down the theme colors vibrancy and add colors to the currently viewed model in both the side navigation and breadcrumbs.
- Auto-close the side navigation in small screens after selecting a different model (changing route).