### PR TITLE
fix: expired-revalidated

### DIFF
--- a/src/components/toolbar/login-button.tsx
+++ b/src/components/toolbar/login-button.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  Box,
   createStyles,
   Dialog,
   DialogContent,
@@ -11,10 +12,16 @@ import {
   useMediaQuery,
   useTheme,
 } from '@material-ui/core';
-import { Close as CloseIcon } from '@material-ui/icons';
+import {
+  CheckCircleOutline as SuccessIcon,
+  Close as CloseIcon,
+  ErrorOutline as ErrorIcon,
+  WarningAmber as WarningIcon,
+} from '@material-ui/icons';
+import { IconButton, IconButtonProps } from '@/components/buttons';
 import LoginForm from '@/components/forms/login-form';
 import useAuth from '@/hooks/useAuth';
-import { IconButton, IconButtonProps } from '../buttons';
+import clsx from 'clsx';
 
 interface LogoutButtonProps extends IconButtonProps {
   onLogin?: () => void;
@@ -36,17 +43,12 @@ export default function LoginButton({
 
   useEffect(
     function renderFeedbackAndText() {
-      if (auth.status === 'failed') console.log('Login failed');
-
-      if (
-        auth.status === 'failed' ||
-        auth.status === 'idle' ||
-        auth.status === 'expired'
-      ) {
-        // t('toolBar.logout')
-      } else if (auth.status === 'success') {
-        setIsFormOpen(false);
-        if (onLogin) onLogin();
+      console.log({ status: auth.status });
+      if (auth.status === 'success') {
+        setTimeout(() => {
+          setIsFormOpen(false);
+          if (onLogin) onLogin();
+        }, 700);
       }
     },
     [auth.status, onLogin]
@@ -98,10 +100,39 @@ export default function LoginButton({
             <CloseIcon />
           </IconButton>
         </DialogTitle>
+
         <DialogContent>
           <DialogContentText id="login-form-dialog-description">
             {t('login-dialog.content')}
           </DialogContentText>
+
+          {auth.status !== 'idle' && auth.status !== 'loading' && (
+            <Box
+              className={clsx(classes.card, {
+                [classes.cardError]: auth.status === 'failed',
+                [classes.cardSuccess]: auth.status === 'success',
+                [classes.cardWarning]: auth.status === 'expired',
+              })}
+            >
+              {auth.status === 'failed' ? (
+                <>
+                  <ErrorIcon />
+                  <h1>Login failed</h1>
+                </>
+              ) : auth.status === 'success' ? (
+                <>
+                  <SuccessIcon />
+                  <h1>Login succesful</h1>
+                </>
+              ) : (
+                <>
+                  <WarningIcon />
+                  <h1>Login expired</h1>
+                </>
+              )}
+            </Box>
+          )}
+
           <LoginForm onSubmit={handleOnLogin} />
         </DialogContent>
       </Dialog>
@@ -123,6 +154,71 @@ const useStyles = makeStyles((theme) =>
       color: theme.palette.grey[500],
       '&:hover': {
         color: theme.palette.secondary.main,
+      },
+    },
+    card: {
+      // Layout
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+
+      // Spacing
+      margin: theme.spacing(6, 0, 4, 0),
+      padding: theme.spacing(3),
+
+      // Background & border styles
+      border: '2px solid',
+      borderRadius: 10,
+
+      // Heading
+      '& h1': {
+        padding: 0,
+        margin: theme.spacing(0, 0, 0, 2),
+        fontSize: theme.spacing(4),
+        textAlign: 'center',
+        [theme.breakpoints.up('sm')]: {
+          fontSize: theme.spacing(5),
+        },
+      },
+
+      // Icon
+      '& svg': {
+        width: theme.spacing(6),
+        height: theme.spacing(6),
+        [theme.breakpoints.up('sm')]: {
+          width: theme.spacing(7),
+          height: theme.spacing(7),
+        },
+      },
+    },
+    cardError: {
+      backgroundColor: theme.palette.error.background,
+      borderColor: theme.palette.error.main,
+      '& h1': {
+        color: theme.palette.error.dark,
+      },
+      '& svg': {
+        color: theme.palette.error.main,
+      },
+    },
+    cardSuccess: {
+      backgroundColor: theme.palette.success.background,
+      borderColor: theme.palette.success.main,
+      '& h1': {
+        color: theme.palette.success.dark,
+      },
+      '& svg': {
+        color: theme.palette.success.main,
+      },
+    },
+    cardWarning: {
+      backgroundColor: theme.palette.warning.background,
+      borderColor: theme.palette.warning.main,
+      '& h1': {
+        color: theme.palette.warning.dark,
+      },
+      '& svg': {
+        color: theme.palette.warning.main,
       },
     },
   })

--- a/src/components/toolbar/login-button.tsx
+++ b/src/components/toolbar/login-button.tsx
@@ -43,7 +43,6 @@ export default function LoginButton({
 
   useEffect(
     function renderFeedbackAndText() {
-      console.log({ status: auth.status });
       if (auth.status === 'success') {
         setTimeout(() => {
           setIsFormOpen(false);
@@ -117,17 +116,17 @@ export default function LoginButton({
               {auth.status === 'failed' ? (
                 <>
                   <ErrorIcon />
-                  <h1>Login failed</h1>
+                  <h1>{t('login-dialog.login-failed')}</h1>
                 </>
               ) : auth.status === 'success' ? (
                 <>
                   <SuccessIcon />
-                  <h1>Login succesful</h1>
+                  <h1>{t('login-dialog.login-successful')}</h1>
                 </>
               ) : (
                 <>
                   <WarningIcon />
-                  <h1>Login expired</h1>
+                  <h1>{t('login-dialog.login-expired')}</h1>
                 </>
               )}
             </Box>

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -8,6 +8,7 @@ import {
   logUserOut,
 } from '@/store/auth-slice';
 import { AuthState } from '@/types/auth';
+import { isTokenValid } from '@/utils/auth';
 
 interface AuthOptions {
   redirectTo: string;
@@ -84,15 +85,9 @@ export default function useAuth(options?: AuthOptions): UseAuth {
    */
   const checkValidToken: AuthValid = useCallback(() => {
     if (!auth.user) return false;
-
-    const currDate = new Date();
-    const expDate = new Date(auth.user?.exp * 1000);
-    if (currDate > expDate) {
-      dispatch(expireUser());
-      return false;
-    }
-
-    return true;
+    const isValid = isTokenValid(auth.user);
+    if (!isValid) dispatch(expireUser());
+    return isValid;
   }, [auth.user, dispatch]);
 
   return { ...auth, checkValidToken, login, logout };

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -28,7 +28,6 @@
   },
   "errors": {
     "csv-import": "Es ist ein Fehler während des CSV Imports aufgetreten. Bitte kontaktieren sie ihren Administrator.",
-    "login-failed": "Anmeldung fehlgeschlagen",
     "server-error": "Fehler {{ status }} in Anfrage zum Server"
   },
   "home": {
@@ -38,7 +37,10 @@
   },
   "login-dialog": {
     "title": "Login Formular",
-    "content": "Um sich auf der Website anzumelden, geben Sie bitte ihre E-Mail-Adresse und Passwort ein."
+    "content": "Um sich auf der Website anzumelden, geben Sie bitte ihre E-Mail-Adresse und Passwort ein.",
+    "login-expired": "Anmenldung abgelaufen",
+    "login-failed": "Anmeldung fehlgeschlagen",
+    "login-successful": "Anmeldung erfolgreich"
   },
   "login-form": {
     "cancel": "Abbrechen",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -108,7 +108,7 @@
     "not-allowed-header": "Zugriff zu dieser Seite ist gepserrt",
     "not-allowed-info": "Es scheint Sie haben nicht ausreichend Zugriffsrechte für die angefragte Seite. Falls Sie glauben dies ist ein Fehler, wenden Sie sich bitte an ihren Administrator.",
     "token-exp-header": "Ihre Sitzung ist abgelaufen",
-    "token-exp-info": "Die aktuelle Sitzung ist abgelaufen. Revalidieren Sie ihre Sitzung mittels Login in der oberen rechten Ecke. Um die aktuelle Sitzung zu beenden nutzen sie den Logout."
+    "token-exp-info": "Die aktuelle Sitzung ist abgelaufen. Revalidieren Sie ihre Sitzung mittels Login in der oberen rechten Ecke. Um die aktuelle Sitzung zu beenden schließen sie das Fenster."
   },
   "success": {
     "assoc-update": "Assoziation erfolgreich aktualisiert",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,7 +108,7 @@
     "not-allowed-header": "Access to this page is restricted",
     "not-allowed-info": "It appears you do not have sufficient permissions to access this page. If you think this is an error, please contact your administrator.",
     "token-exp-header": "Your session has expired",
-    "token-exp-info": "It appears your current session has expired. This page will not function until you re-validate your identity. You can do so using the sign-in button in the top right corner. You may also exit the current session by clicking on the Logout button below."
+    "token-exp-info": "It appears your current session has expired. This page will not function until you re-validate your identity. You can do so using the sign-in button in the top right corner. You may also exit the current session by closing this window."
   },
   "success": {
     "assoc-update": "Associations updated successfully",
@@ -116,7 +116,6 @@
   },
   "toolbar": {
     "change-language": "Change language",
-    "login": "Login",
-    "logout": "Logout"
+    "login": "Login"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,7 +28,6 @@
   },
   "errors": {
     "csv-import": "An error occurred while trying to import the CSV file. Please contact your administrator.",
-    "login-failed": "Login failed",
     "server-error": "Error {{ status }} in request to server"
   },
   "home": {
@@ -38,7 +37,10 @@
   },
   "login-dialog": {
     "title": "Login Form",
-    "content": "To log into this website, please enter your email address and password below."
+    "content": "To log into this website, please enter your email address and password below.",
+    "login-expired": "Login expired",
+    "login-failed": "Login failed",
+    "login-successful": "Login successful"
   },
   "login-form": {
     "cancel": "Cancel",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -28,7 +28,6 @@
   },
   "errors": {
     "csv-import": "",
-    "login-failed": "",
     "server-error": ""
   },
   "home": {
@@ -38,7 +37,10 @@
   },
   "login-dialog": {
     "title": "",
-    "content": ""
+    "content": "",
+    "login-expired": "",
+    "login-failed": "",
+    "login-successful": ""
   },
   "login-form": {
     "cancel": "",

--- a/src/layouts/models/model-restricted.tsx
+++ b/src/layouts/models/model-restricted.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Box, Button } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import {
   InfoOutlined as InfoIcon,
@@ -32,11 +32,6 @@ export default function Restricted(
   const isNotLoggedIn = auth.user === undefined;
   const isNotAllowed =
     urlQuery.model && !getModel(urlQuery.model).permissions.read;
-
-  const handleTerminateSession = (): void => {
-    router.push('/');
-    auth.logout();
-  };
 
   if (isNotLoggedIn || isNotAllowed) {
     return (
@@ -77,9 +72,6 @@ export default function Restricted(
           <Box className={classes.cardContent}>
             <h1>{t('restricted.token-exp-header')}</h1>
             <p>{t('restricted.token-exp-info')}</p>
-            <Button size="small" onClick={handleTerminateSession}>
-              {t('toolbar.logout')}
-            </Button>
           </Box>
         </Box>
       )}

--- a/src/layouts/models/model-restricted.tsx
+++ b/src/layouts/models/model-restricted.tsx
@@ -66,7 +66,7 @@ export default function Restricted(
 
   return (
     <>
-      {auth.status === 'expired' && (
+      {auth.status !== 'success' && (
         <Box className={clsx(classes.card, classes.cardWarning)}>
           <WarningIcon />
           <Box className={classes.cardContent}>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -58,6 +58,12 @@ export const theme = createMuiTheme({
   spacing: (value: number) => defaultTheme.typography.pxToRem(value / 0.25),
   // spacing: (value: number) => `${0.25 * value}rem`,
   palette: {
+    error: {
+      background: red[50],
+      light: red[200],
+      main: red[600],
+      dark: red[700],
+    },
     primary: {
       background: blue[50],
       light: blue[100],
@@ -70,17 +76,17 @@ export const theme = createMuiTheme({
       main: red[600],
       dark: red[700],
     },
-    warning: {
-      background: yellow[50],
-      light: yellow[100],
-      main: yellow[600],
-      dark: yellow[700],
-    },
     success: {
       background: green[50],
       light: green[100],
       main: green[600],
       dark: green[700],
+    },
+    warning: {
+      background: yellow[50],
+      light: yellow[100],
+      main: yellow[600],
+      dark: yellow[700],
     },
   },
   color: {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -2,8 +2,10 @@ import { SerializedError } from '@reduxjs/toolkit';
 import { AclPermission } from './acl';
 
 export const AUTH_TOKEN_NOT_FOUND = 'AUTH_TOKEN_NOT_FOUND';
+export const AUTH_TOKEN_EXPIRED = 'AUTH_TOKEN_EXPIRED';
 export const AUTH_PERMISSIONS_NOT_FOUND = 'AUTH_PERMISSIONS_NOT_FOUND';
 export const AUTH_REQUEST_CANCELLED = 'AUTH_REQUEST_CANCELLED';
+
 export class AuthError extends Error implements SerializedError {
   public code: string;
   constructor(code: string, message?: string) {


### PR DESCRIPTION
## Summary

This PR applies additional fixes to PR #67, building on the discussion in #64.

## Changes

- When authenticating into a new page or tab, the store will no longer reuse a token if it is expired.
- The additional logout button in the session expired warning is now superfluous (can just close the tab or window) and has been removed.
- Display login dialog feedback on current authentication status (expired, failed, success).
- Add `error` and `success` color palettes (used in dialog feedback).

## Future

- Create an alert component to display the feedback messages displayed in pages (login expired, not logged in) and in the login form (successful, failed, expired).
- Revisit the login-form dialog layout so that the message is less "jumpy".
- Review the login more carefully and possibly add reason for login failed (e.g. server not responding, offline, or credentials incorrect).