### PR TITLE
styles: record-page ux and styles

### DIFF
--- a/src/pages/[group]/[model]/details.tsx
+++ b/src/pages/[group]/[model]/details.tsx
@@ -163,10 +163,9 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             disabled={model.schema.associations?.length === 0}
           />
         </TabList>
-        <TabPanel value="attributes" className={classes.panelForm}>
+        <TabPanel value="attributes">
           <AttributesForm
             attributes={model.schema.attributes}
-            className={classes.form}
             data={recordData}
             disabled
             formId={router.asPath}
@@ -196,24 +195,30 @@ const Record: PageWithLayout<RecordProps> = (props) => {
 
 const useStyles = makeStyles((theme) =>
   createStyles({
-    form: {
-      border: '2px solid',
-      borderRadius: 10,
-      borderColor: theme.palette.grey[300],
-      padding: theme.spacing(12, 10),
-    },
-    panelForm: {
-      margin: theme.spacing(10, 0),
-    },
     panelTable: {
       display: 'flex',
       flexGrow: 1,
       margin: theme.spacing(5, 2),
     },
     tabList: {
-      margin: theme.spacing(0, 4),
-      // borderBottom: '1px solid',
-      // borderBottomColor: theme.palette.divider,
+      backgroundColor: theme.palette.action.hover,
+      borderBottom: '1px solid',
+      borderBottomColor: theme.palette.divider,
+
+      '& .MuiTabs-indicator': {
+        backgroundColor: 'transparent',
+      },
+
+      '& .MuiTab-root:hover:not(.Mui-selected)': {
+        backgroundColor: theme.palette.background.default,
+        color: theme.palette.getContrastText(theme.palette.background.default),
+      },
+
+      '& .Mui-selected': {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.getContrastText(theme.palette.primary.main),
+        fontWeight: 'bold',
+      },
     },
   })
 );

--- a/src/pages/[group]/[model]/details.tsx
+++ b/src/pages/[group]/[model]/details.tsx
@@ -178,7 +178,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             }}
           />
         </TabPanel>
-        <TabPanel value="associations" className={classes.panelTable}>
+        <TabPanel value="associations" className={classes.tabPanel}>
           <AssociationsTable
             associationView="details"
             associations={model.schema.associations ?? []}
@@ -195,12 +195,9 @@ const Record: PageWithLayout<RecordProps> = (props) => {
 
 const useStyles = makeStyles((theme) =>
   createStyles({
-    panelTable: {
-      display: 'flex',
-      flexGrow: 1,
-      margin: theme.spacing(5, 2),
-    },
     tabList: {
+      marginBottom: theme.spacing(6),
+
       backgroundColor: theme.palette.action.hover,
       borderBottom: '1px solid',
       borderBottomColor: theme.palette.divider,
@@ -219,6 +216,10 @@ const useStyles = makeStyles((theme) =>
         color: theme.palette.getContrastText(theme.palette.primary.main),
         fontWeight: 'bold',
       },
+    },
+    tabPanel: {
+      display: 'flex',
+      flexGrow: 1,
     },
   })
 );

--- a/src/pages/[group]/[model]/edit.tsx
+++ b/src/pages/[group]/[model]/edit.tsx
@@ -308,10 +308,9 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             disabled={model.schema.associations?.length === 0}
           />
         </TabList>
-        <TabPanel value="attributes" className={classes.panelForm}>
+        <TabPanel value="attributes">
           <AttributesForm
             attributes={model.schema.attributes}
-            className={classes.form}
             data={recordData}
             errors={ajvErrors}
             formId={router.asPath}
@@ -343,22 +342,30 @@ const Record: PageWithLayout<RecordProps> = (props) => {
 
 const useStyles = makeStyles((theme) =>
   createStyles({
-    form: {
-      border: '2px solid',
-      borderRadius: 10,
-      borderColor: theme.palette.grey[300],
-      padding: theme.spacing(12, 10),
-    },
-    panelForm: {
-      margin: theme.spacing(10, 0),
-    },
     panelTable: {
       display: 'flex',
       flexGrow: 1,
       margin: theme.spacing(5, 2),
     },
     tabList: {
-      margin: theme.spacing(0, 4),
+      backgroundColor: theme.palette.action.hover,
+      borderBottom: '1px solid',
+      borderBottomColor: theme.palette.divider,
+
+      '& .MuiTabs-indicator': {
+        backgroundColor: 'transparent',
+      },
+
+      '& .MuiTab-root:hover:not(.Mui-selected)': {
+        backgroundColor: theme.palette.background.default,
+        color: theme.palette.getContrastText(theme.palette.background.default),
+      },
+
+      '& .Mui-selected': {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.getContrastText(theme.palette.primary.main),
+        fontWeight: 'bold',
+      },
     },
   })
 );

--- a/src/pages/[group]/[model]/edit.tsx
+++ b/src/pages/[group]/[model]/edit.tsx
@@ -325,7 +325,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             }}
           />
         </TabPanel>
-        <TabPanel className={classes.panelTable} value="associations">
+        <TabPanel className={classes.tabPanel} value="associations">
           <AssociationsTable
             associationView="update"
             associations={model.schema.associations ?? []}
@@ -342,12 +342,9 @@ const Record: PageWithLayout<RecordProps> = (props) => {
 
 const useStyles = makeStyles((theme) =>
   createStyles({
-    panelTable: {
-      display: 'flex',
-      flexGrow: 1,
-      margin: theme.spacing(5, 2),
-    },
     tabList: {
+      marginBottom: theme.spacing(6),
+
       backgroundColor: theme.palette.action.hover,
       borderBottom: '1px solid',
       borderBottomColor: theme.palette.divider,
@@ -366,6 +363,10 @@ const useStyles = makeStyles((theme) =>
         color: theme.palette.getContrastText(theme.palette.primary.main),
         fontWeight: 'bold',
       },
+    },
+    tabPanel: {
+      display: 'flex',
+      flexGrow: 1,
     },
   })
 );

--- a/src/pages/[group]/[model]/new.tsx
+++ b/src/pages/[group]/[model]/new.tsx
@@ -3,8 +3,6 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { createStyles, makeStyles } from '@material-ui/core';
-
 import { getStaticModelPaths } from '@/build/routes';
 
 import {
@@ -54,7 +52,6 @@ const Record: PageWithLayout<RecordProps> = (props) => {
   const dialog = useDialog();
   const model = useModel(props.model);
   const router = useRouter();
-  const classes = useStyles();
   const { showSnackbar } = useToastNotification();
   const zendro = useZendroClient();
   const { t } = useTranslation();
@@ -158,7 +155,6 @@ const Record: PageWithLayout<RecordProps> = (props) => {
     <ModelBouncer object={props.model} action="create">
       <AttributesForm
         attributes={model.schema.attributes}
-        className={classes.form}
         errors={ajvErrors}
         formId={router.asPath}
         formView="create"
@@ -171,18 +167,6 @@ const Record: PageWithLayout<RecordProps> = (props) => {
     </ModelBouncer>
   );
 };
-
-const useStyles = makeStyles((theme) =>
-  createStyles({
-    form: {
-      border: '2px solid',
-      borderRadius: 10,
-      borderColor: theme.palette.grey[300],
-      margin: theme.spacing(10, 4),
-      padding: theme.spacing(12, 10),
-    },
-  })
-);
 
 Record.layout = ModelLayout;
 export default Record;

--- a/src/zendro/record-form/form-header.tsx
+++ b/src/zendro/record-form/form-header.tsx
@@ -1,7 +1,7 @@
-import React, { ReactElement } from 'react';
+import React, { PropsWithChildren, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Tooltip } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
-import { Box, Tooltip, Typography } from '@material-ui/core';
 import { Lock as LockIcon } from '@material-ui/icons';
 
 interface FormHeaderProps {
@@ -16,40 +16,98 @@ export default function FormHeader({
   prefix,
   subtitle,
   title,
-}: FormHeaderProps): ReactElement {
+  ...props
+}: PropsWithChildren<FormHeaderProps>): ReactElement {
   const classes = useStyles();
   const { t } = useTranslation();
 
   return (
-    <Box
-      component="legend"
-      display="flex"
-      justifyContent="space-between"
-      marginX={9.5}
-      mb={6}
-    >
-      <Box display="flex" alignItems="center">
-        {locked && (
-          <Tooltip title={t('record-form.read-only')}>
-            <LockIcon color="secondary" className={classes.lockedFormIcon} />
-          </Tooltip>
-        )}
+    <legend className={classes.legend}>
+      <div>
+        <h1>
+          {locked && (
+            <Tooltip title={t('record-form.read-only')}>
+              <LockIcon color="secondary" />
+            </Tooltip>
+          )}
+          <span>
+            {prefix && <span className={classes.titlePrefix}>{prefix}</span>}
+            <span className={classes.title}>{title}</span>
+          </span>
+        </h1>
 
-        <Typography variant="h6" component="h1">
-          {prefix && <span className={classes.titlePrefix}>{prefix}</span>}
-          <span className={classes.title}>{title}</span>
-        </Typography>
-      </Box>
+        <h2>{subtitle}</h2>
+      </div>
 
-      <Typography variant="subtitle1" color="textSecondary">
-        {subtitle}
-      </Typography>
-    </Box>
+      <section aria-label="additional-form-info">{props.children}</section>
+    </legend>
   );
 }
 
 const useStyles = makeStyles((theme) =>
   createStyles({
+    legend: {
+      // Layout
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+
+      [theme.breakpoints.only('md')]: {
+        flexDirection: 'row',
+        alignItems: 'start',
+        justifyContent: 'space-between',
+      },
+
+      [theme.breakpoints.up('lg')]: {
+        alignItems: 'start',
+      },
+
+      // Spacing
+      margin: theme.spacing(5, 0, 6, 0),
+      [theme.breakpoints.up('md')]: {
+        margin: theme.spacing(5, 9.5, 6, 9.5),
+      },
+
+      // Title
+      '& > div': {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        [theme.breakpoints.up('md')]: {
+          alignItems: 'start',
+        },
+
+        '& > h1': {
+          ...theme.typography.h6,
+          margin: theme.spacing(0, 0, 2, 0),
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+
+          [theme.breakpoints.up('md')]: {
+            flexDirection: 'row',
+          },
+
+          '& > svg': {
+            marginRight: theme.spacing(2),
+          },
+        },
+
+        '& > h2': {
+          ...theme.typography.subtitle1,
+          margin: theme.spacing(0, 0, 0, 0),
+          color: theme.palette.text.secondary,
+        },
+      },
+
+      // Custom info
+      '& > section': {
+        margin: theme.spacing(4, 0, 0, 0),
+        [theme.breakpoints.up('lg')]: {
+          margin: theme.spacing(4, 0, 0, 0),
+        },
+      },
+    },
     titlePrefix: {
       ...theme.typography.h6,
       color: 'GrayText',
@@ -59,9 +117,6 @@ const useStyles = makeStyles((theme) =>
     },
     title: {
       fontWeight: 'bold',
-    },
-    lockedFormIcon: {
-      marginRight: theme.spacing(2),
     },
   })
 );

--- a/src/zendro/record-form/form.tsx
+++ b/src/zendro/record-form/form.tsx
@@ -1,14 +1,14 @@
-import clsx from 'clsx';
 import React, {
   PropsWithChildren,
   ReactElement,
+  ReactNode,
   useEffect,
   useMemo,
   useReducer,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Box, Tooltip } from '@material-ui/core';
+import { Container, Tooltip } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import {
   Cached as Reload,
@@ -48,6 +48,7 @@ export interface AttributesFormProps {
   errors?: Record<string, string[]>;
   formId: string;
   formView: FormView;
+  info?: ReactNode;
   modelName: string;
 }
 
@@ -75,6 +76,7 @@ export default function AttributesForm({
   formId,
   formView,
   modelName,
+  ...props
 }: PropsWithChildren<AttributesFormProps>): ReactElement {
   const classes = useStyles();
   const { t } = useTranslation();
@@ -163,99 +165,87 @@ export default function AttributesForm({
   };
 
   return (
-    <Box position="relative" className={className}>
-      <Box
-        position="absolute"
-        display="flex"
-        justifyContent="space-between"
-        top={-28}
-        right={0}
-        paddingX={10}
-        width="100%"
-      >
-        <div className={clsx(classes.actions, classes.leftActions)}>
-          {actions?.cancel && (
-            <ActionButton
-              className={classes.actionSecondary}
-              form={formId}
-              onClick={handleOnAction({
-                action: 'cancel',
-                handler: actions.cancel,
-              })}
-              icon={CancelIcon}
-              tooltip={t('record-form.action-exit')}
-            />
-          )}
+    <Container maxWidth="lg" className={className}>
+      <div className={classes.actionsContainer}>
+        {actions?.cancel && (
+          <ActionButton
+            className="secondary"
+            form={formId}
+            onClick={handleOnAction({
+              action: 'cancel',
+              handler: actions.cancel,
+            })}
+            icon={CancelIcon}
+            tooltip={t('record-form.action-exit')}
+          />
+        )}
 
-          {actions?.read && (
-            <ActionButton
-              className={classes.actionSupport}
-              form={formId}
-              icon={ReadIcon}
-              onClick={handleOnAction({
-                action: 'read',
-                handler: actions.read,
-              })}
-              tooltip={t('record-form.action-read')}
-            />
-          )}
+        {actions?.read && (
+          <ActionButton
+            className="support"
+            form={formId}
+            icon={ReadIcon}
+            onClick={handleOnAction({
+              action: 'read',
+              handler: actions.read,
+            })}
+            tooltip={t('record-form.action-read')}
+          />
+        )}
 
-          {actions?.update && (
-            <ActionButton
-              className={classes.actionSupport}
-              form={formId}
-              icon={EditIcon}
-              onClick={handleOnAction({
-                action: 'update',
-                handler: actions.update,
-              })}
-              tooltip={t('record-form.action-update')}
-            />
-          )}
-        </div>
+        {actions?.update && (
+          <ActionButton
+            className="support"
+            form={formId}
+            icon={EditIcon}
+            onClick={handleOnAction({
+              action: 'update',
+              handler: actions.update,
+            })}
+            tooltip={t('record-form.action-update')}
+          />
+        )}
 
-        <div className={clsx(classes.actions, classes.rightActions)}>
-          {actions?.delete && (
-            <ActionButton
-              className={classes.actionSecondary}
-              form={formId}
-              icon={DeleteIcon}
-              onClick={handleOnAction({
-                action: 'delete',
-                handler: actions.delete,
-              })}
-              tooltip={t('record-form.action-delete')}
-            />
-          )}
+        {actions?.delete && (
+          <ActionButton
+            className="secondary"
+            form={formId}
+            icon={DeleteIcon}
+            onClick={handleOnAction({
+              action: 'delete',
+              handler: actions.delete,
+            })}
+            tooltip={t('record-form.action-delete')}
+          />
+        )}
 
-          {actions?.reload && (
-            <ActionButton
-              className={classes.actionSupport}
-              form={formId}
-              icon={Reload}
-              tooltip={t('record-form.action-reload')}
-              onClick={handleOnAction({
-                action: 'reload',
-                handler: actions.reload,
-              })}
-            />
-          )}
+        {actions?.reload && (
+          <ActionButton
+            className="support"
+            form={formId}
+            icon={Reload}
+            tooltip={t('record-form.action-reload')}
+            onClick={handleOnAction({
+              action: 'reload',
+              handler: actions.reload,
+            })}
+          />
+        )}
 
-          {actions?.submit && (
-            <ActionButton
-              className={classes.actionPrimary}
-              form={formId}
-              icon={SaveIcon}
-              tooltip={t('record-form.action-submit')}
-              type="submit"
-              onClick={handleOnAction({
-                action: 'submit',
-                handler: actions.submit,
-              })}
-            />
-          )}
-        </div>
-      </Box>
+        {actions?.submit && (
+          <ActionButton
+            className="primary"
+            form={formId}
+            icon={SaveIcon}
+            tooltip={t('record-form.action-submit')}
+            type="submit"
+            onClick={handleOnAction({
+              action: 'submit',
+              handler: actions.submit,
+            })}
+          />
+        )}
+      </div>
 
       <form id={formId} className={classes.form}>
         <FormHeader
@@ -267,102 +257,137 @@ export default function AttributesForm({
           subtitle={`${t('record-form.completed')} ${
             formAttributes.length - formStats.unset
           } / ${formAttributes.length}`}
-        />
+        >
+          {props.info}
+        </FormHeader>
 
-        {formAttributes.map((attribute) => {
-          const {
-            name,
-            type,
-            value,
-            clientError,
-            serverErrors,
-            readOnly,
-            primaryKey,
-          } = attribute;
+        <section
+          aria-label={`${formId}-input-fields`}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flexGrow: 1,
+          }}
+        >
+          {formAttributes.map((attribute) => {
+            const {
+              name,
+              type,
+              value,
+              clientError,
+              serverErrors,
+              readOnly,
+              primaryKey,
+            } = attribute;
 
-          return (
-            <FormField
-              key={name}
-              type={type}
-              error={clientError || serverErrors ? true : false}
-              helperText={
-                clientError || serverErrors
-                  ? {
-                      component: 'ul',
-                      node: (
-                        <FormErrors
-                          ajvValidation={serverErrors}
-                          clientValidation={clientError}
-                        />
-                      ),
-                    }
-                  : undefined
-              }
-              label={name}
-              actionLeft={
-                primaryKey && (
-                  <Tooltip title={t('record-fields.primary-key', { name })}>
-                    <KeyIcon fontSize="small" color="action" />
-                  </Tooltip>
-                )
-              }
-              readOnly={readOnly}
-              actionRight={
-                readOnly && (
-                  <Tooltip title={t('record-fields.read-only')}>
-                    <LockIcon fontSize="small" color="secondary" />
-                  </Tooltip>
-                )
-              }
-              onChange={!disabled ? handleOnChange(name) : undefined}
-              onError={!disabled ? handleOnError(name) : undefined}
-              value={value}
-            />
-          );
-        })}
+            return (
+              <FormField
+                key={name}
+                type={type}
+                error={clientError || serverErrors ? true : false}
+                helperText={
+                  clientError || serverErrors
+                    ? {
+                        component: 'ul',
+                        node: (
+                          <FormErrors
+                            ajvValidation={serverErrors}
+                            clientValidation={clientError}
+                          />
+                        ),
+                      }
+                    : undefined
+                }
+                label={name}
+                actionLeft={
+                  primaryKey && (
+                    <Tooltip title={t('record-fields.primary-key', { name })}>
+                      <KeyIcon fontSize="small" color="action" />
+                    </Tooltip>
+                  )
+                }
+                readOnly={readOnly}
+                actionRight={
+                  readOnly ? (
+                    <Tooltip title={t('record-fields.read-only')}>
+                      <LockIcon fontSize="small" color="secondary" />
+                    </Tooltip>
+                  ) : null
+                }
+                onChange={!disabled ? handleOnChange(name) : undefined}
+                onError={!disabled ? handleOnError(name) : undefined}
+                value={value}
+              />
+            );
+          })}
+        </section>
       </form>
-    </Box>
+    </Container>
   );
 }
 
 const useStyles = makeStyles((theme) =>
   createStyles({
     form: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+
+      [theme.breakpoints.up('lg')]: {
+        flexDirection: 'row',
+        alignItems: 'start',
+      },
+
       marginTop: theme.spacing(6),
     },
-    actions: {
+    actionsContainer: {
+      // Layout
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-around',
+
+      [theme.breakpoints.up('sm')]: {
+        justifyContent: 'center',
+        '& > button:not(:last-child), a:not(:last-child)': {
+          marginRight: theme.spacing(6),
+        },
+      },
+
+      [theme.breakpoints.only('md')]: {
+        justifyContent: 'flex-start',
+        marginLeft: theme.spacing(9.5),
+      },
+
+      [theme.breakpoints.up('lg')]: {
+        justifyContent: 'flex-end',
+        marginRight: theme.spacing(9.5),
+      },
+
+      // Spacing
+      margin: theme.spacing(4, 0),
+
+      // Buttons
       '& > button, a': {
-        width: theme.spacing(12),
-        height: theme.spacing(12),
+        flexShrink: 0,
+        width: theme.spacing(10),
+        height: theme.spacing(10),
       },
-      '& > button:not(:first-child), a:not(:first-child)': {
-        marginLeft: theme.spacing(6),
+
+      '& .primary': {
+        color: theme.palette.primary.background,
+        backgroundColor: theme.palette.primary.main,
+        '&:hover': {
+          backgroundColor: theme.palette.primary.dark,
+        },
       },
-    },
-    leftActions: {
-      '& > button:first-child, a:first-child': {
-        width: theme.spacing(14),
-        height: theme.spacing(14),
+
+      '& .secondary': {
+        color: theme.palette.secondary.main,
       },
-    },
-    rightActions: {
-      '& > button:last-child, a:last-child': {
-        width: theme.spacing(14),
-        height: theme.spacing(14),
+
+      '& .support': {
+        color: theme.palette.primary.main,
       },
-    },
-    actionPrimary: {
-      color: theme.palette.grey[100],
-      backgroundColor: theme.palette.primary.main,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.dark,
-      },
-    },
-    actionSecondary: {
-      color: theme.palette.secondary.main,
-    },
-    actionSupport: {
-      color: theme.palette.primary.main,
     },
   })
 );

--- a/src/zendro/record-form/form.tsx
+++ b/src/zendro/record-form/form.tsx
@@ -364,7 +364,7 @@ const useStyles = makeStyles((theme) =>
       },
 
       // Spacing
-      margin: theme.spacing(4, 0),
+      marginBottom: theme.spacing(4),
 
       // Buttons
       '& > button, a': {


### PR DESCRIPTION
## Summary

This PR slightly improves the UX of the record page tabs and attributes form.

## Changes
- The passing `children` to the `form-header` component. The header responsive styles have been adjusted to accommodate this new node.
- Add a new `info` prop to the `form` with type `ReactNode` that is passed as a child of `form-header`.
- The form actions are now part of the normal document flow and fully responsive.
- Style the record page tabs for `details` and `edit` similarly to other navigation elements.
- Standardize margins on the record page tab-list margins to slightly increase the spacing with the tab panels.