### PR TITLE
fix: Untwist fixes merge

### DIFF
--- a/src/build/queries.preval.ts
+++ b/src/build/queries.preval.ts
@@ -11,21 +11,23 @@ async function buildQueries(): Promise<Record<string, StaticQueries>> {
   for (const [model, { withFilter, ...queries }] of Object.entries(
     modelQueries
   )) {
-    const modelDir = `src/custom/queries/${model}`;
-    await mkdir(modelDir, { recursive: true });
+    const modelQueriesDir = `src/custom/queries/${model}`;
+    await mkdir(modelQueriesDir, { recursive: true });
 
     // Generate in-model queries
     for (const { name, query } of Object.values(queries)) {
       await writeFile(
-        join(modelDir, name) + '.gql',
+        join(modelQueriesDir, name) + '.gql',
         format(query, { parser: 'graphql' })
       );
     }
     // Generate association queries
+    const modelAssocQueriesDir = join(modelQueriesDir, 'associations');
+    await mkdir(modelAssocQueriesDir, { recursive: true });
     for (const assocQueries of Object.values(withFilter)) {
       for (const { name, query } of Object.values(assocQueries)) {
         await writeFile(
-          join(modelDir, name) + '.gql',
+          join(modelQueriesDir, 'associations', name) + '.gql',
           format(query, { parser: 'graphql' })
         );
       }

--- a/src/build/routes.preval.ts
+++ b/src/build/routes.preval.ts
@@ -4,16 +4,19 @@ import { AppRoutes2 } from '@/types/routes';
 import { getStaticRoutes2 } from './routes';
 
 async function buildRoutes(): Promise<AppRoutes2> {
-  const routesJson = process.cwd() + '/src/custom/routes.json';
-  let routes: AppRoutes2;
+  const routesFile = 'routes.json';
+  const customPath = process.cwd() + `/src/custom/${routesFile}`;
+  const overridePath = process.cwd() + `/src/${routesFile}`;
+
+  let routes = await getStaticRoutes2();
+  await mkdir('src/custom', { recursive: true });
+  await writeFile(customPath, JSON.stringify(routes, null, 2));
 
   try {
-    await stat(routesJson);
-    routes = require(routesJson);
+    await stat(overridePath);
+    routes = require(overridePath);
   } catch (error) {
-    routes = await getStaticRoutes2();
-    await mkdir('src/custom', { recursive: true });
-    await writeFile(routesJson, JSON.stringify(routes, null, 2));
+    console.log('Override for "routes.json" not found. Loading defaults.');
   }
 
   return routes;

--- a/src/components/select-input/select-input.tsx
+++ b/src/components/select-input/select-input.tsx
@@ -23,27 +23,18 @@ interface StyledSelectProps {
   id?: string;
   items: SelectItem[];
   label?: string;
-  onChange?: (itemId: string, itemText: string) => void;
+  onChange?: (itemId: string) => void;
   defaultValue?: string;
   selected: string;
 }
 
 export default function SelectInput(props: StyledSelectProps): ReactElement {
-  // const [selected, setSelected] = useState<string>(
-  //   props.defaultValue ?? props.items[0].id
-  // );
   const classes = useStyles();
 
   const handleOnChange = (
     event: React.ChangeEvent<{ value: string }>
   ): void => {
-    // setSelected(event.target.value);
-
-    const { id, text } = props.items.find(
-      (assoc) => assoc.id === event.target.value
-    ) as SelectItem;
-
-    if (props.onChange) props.onChange(id, text);
+    if (props.onChange) props.onChange(event.target.value);
   };
 
   return (

--- a/src/zendro/associations-table/table.tsx
+++ b/src/zendro/associations-table/table.tsx
@@ -157,7 +157,6 @@ export default function AssociationsTable({
     error: Error | ExtendedClientError
   ): void => {
     const parsedError = parseErrorResponse(error);
-    console.log({ parsedError });
 
     if (parsedError.networkError) {
       showSnackbar(parsedError.networkError, 'error');
@@ -186,7 +185,7 @@ export default function AssociationsTable({
   >(
     [
       recordsFilter,
-      selectedAssoc.name,
+      selectedAssoc,
       tableSearch,
       tableOrder,
       tablePagination,
@@ -195,9 +194,9 @@ export default function AssociationsTable({
     async () => {
       const recordsQuery: AssocQuery =
         associationView === 'details' || recordsFilter === 'associated'
-          ? zendro.queries[modelName].withFilter[selectedAssoc.target]
+          ? zendro.queries[modelName].withFilter[selectedAssoc.name]
               .readFiltered
-          : zendro.queries[modelName].withFilter[selectedAssoc.target].readAll;
+          : zendro.queries[modelName].withFilter[selectedAssoc.name].readAll;
 
       const variables: QueryModelTableRecordsVariables = {
         search: tableSearch,
@@ -272,12 +271,12 @@ export default function AssociationsTable({
   /* FETCH COUNT */
   const { mutate: mutateCount } = useSWR<Record<'count', number> | undefined>(
     selectedAssoc.type !== 'to_one'
-      ? [recordsFilter, selectedAssoc.target, tableSearch, zendro]
+      ? [recordsFilter, selectedAssoc, tableSearch, zendro]
       : null,
     async () => {
       const countQuery =
         associationView === 'details' || recordsFilter === 'associated'
-          ? zendro.queries[modelName].withFilter[selectedAssoc.target]
+          ? zendro.queries[modelName].withFilter[selectedAssoc.name]
               .countFiltered
           : zendro.queries[selectedAssoc.target].countAll;
 
@@ -300,6 +299,7 @@ export default function AssociationsTable({
         }
       },
       onError: parseAndDisplayErrorResponse,
+      shouldRetryOnError: false,
     }
   );
 

--- a/src/zendro/associations-table/table.tsx
+++ b/src/zendro/associations-table/table.tsx
@@ -307,18 +307,18 @@ export default function AssociationsTable({
 
   const handleOnAsociationSelect = (target: string, name: string): void => {
     const assoc = associations.find(
-      (association) => association.target === target
+      (association) => association.name === name
     ) as ParsedAssociation;
-    if (target !== selectedAssoc.target) {
+    if (name !== selectedAssoc.name) {
       setOrder(undefined);
       setSelectedRecords({
         toAdd: [],
         toRemove: [],
       });
 
-      const model = getModel(target);
+      const model = getModel(assoc.target);
       setSelectedAssoc({
-        target,
+        target: assoc.target,
         name,
         type: assoc.type,
         attributes: model.schema.attributes,
@@ -507,13 +507,13 @@ export default function AssociationsTable({
             id={`${modelName}-association-select`}
             // label={`Select ${modelName} association`}
             label={t('associations.assoc-select', { modelName })}
-            items={associations.map(({ name, target, type }) => ({
-              id: target,
+            items={associations.map(({ name, type }) => ({
+              id: name,
               text: name,
               icon: type === 'to_many' ? ToManyIcon : ToOneIcon,
             }))}
             onChange={handleOnAsociationSelect}
-            selected={selectedAssoc.target}
+            selected={selectedAssoc.name}
           />
         </div>
       </div>

--- a/src/zendro/associations-table/table.tsx
+++ b/src/zendro/associations-table/table.tsx
@@ -305,7 +305,7 @@ export default function AssociationsTable({
 
   /* HANDLERS */
 
-  const handleOnAsociationSelect = (target: string, name: string): void => {
+  const handleOnAsociationSelect = (name: string): void => {
     const assoc = associations.find(
       (association) => association.name === name
     ) as ParsedAssociation;


### PR DESCRIPTION
## Summary

This PR merges fixes done to the association query generation as well as to the association select in the table from untwist-db.

## Changes
- fix association queries / resolverNames / query-transforms
- fix association select menu in the table-toolbar to use the association name as id instead of target
- add associaitons folder to custom/queries containing the association queries
- use separte acl rules override file for the user. If this is not found fall back to the defaults