### PR TITLE
fix: auth-based permissions

### DIFF
--- a/src/hooks/useModel.ts
+++ b/src/hooks/useModel.ts
@@ -20,10 +20,7 @@ export function useModel(modelName?: string): Model | GetModel {
 
   const getModel = useCallback(
     (modelName: string): Model => {
-      const permissions = getResourcePermissions(
-        user?.permissions ?? {},
-        modelName
-      );
+      const permissions = getResourcePermissions(modelName, user?.permissions);
 
       return {
         permissions,

--- a/src/utils/acl.ts
+++ b/src/utils/acl.ts
@@ -28,8 +28,8 @@ export function aclSetResourceReducer(
  * @returns a CRUD->boolean map object.
  */
 export function getResourcePermissions(
-  permissions: AuthPermissions,
-  resource: string
+  resource: string,
+  permissions?: AuthPermissions
 ): ParsedPermissions {
   const defaultPermissions: ParsedPermissions = {
     create: false,
@@ -38,27 +38,33 @@ export function getResourcePermissions(
     delete: false,
   };
 
+  // Without user permissions (e.g. not logged in), access to the resource is forbidden
+  if (!permissions) return defaultPermissions;
+
   const aclPermissions = permissions[resource];
 
-  const parsedPermissions = aclPermissions
-    ? aclPermissions.reduce(
-        (acc, x) =>
-          x === '*'
-            ? Object.assign(acc, {
-                create: true,
-                read: true,
-                update: true,
-                delete: true,
-              })
-            : Object.assign(acc, { [x]: true }),
-        defaultPermissions
-      )
-    : {
-        create: true,
-        read: true,
-        update: true,
-        delete: true,
-      };
+  // When the resource is not controlled, full access is granted to the user
+  if (!aclPermissions)
+    return {
+      create: true,
+      read: true,
+      update: true,
+      delete: true,
+    };
+
+  // When the resource is controlled, permissions are parsed
+  const parsedPermissions = aclPermissions.reduce(
+    (acc, x) =>
+      x === '*'
+        ? Object.assign(acc, {
+            create: true,
+            read: true,
+            update: true,
+            delete: true,
+          })
+        : Object.assign(acc, { [x]: true }),
+    defaultPermissions
+  );
 
   return parsedPermissions;
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug whereby an un-authenticated user could see (but not access) the routes to otherwise protected model resources.

## Changes

The utility function `getResourcePermissions` now accepts an undefined set of permissions. This is the default case for un-authenticated users. Three possible states are evaluated:

### Un-authenticated
- Permissions are not defined.
- Access is restricted to all resources.

### Uncontrolled resource
- Permissions are defined, but not for the current resource.
- Full access is granted to the resource.

### Controlled resource
- Permissions are defined for the current resource.
- Access is granted accordingly.