### PR TITLE
feat: style and format fixes

### DIFF
--- a/src/layouts/app/app-layout.tsx
+++ b/src/layouts/app/app-layout.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import React, { PropsWithChildren, ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,10 +18,12 @@ import { useAuth } from '@/hooks';
 export interface AppLayoutProps {
   brand?: string;
   action?: ReactNode;
+  footer?: boolean;
 }
 
 export default function ModelsLayout({
-  brand,
+  brand = 'Zendro',
+  footer = true,
   ...props
 }: PropsWithChildren<AppLayoutProps>): ReactElement {
   const auth = useAuth();
@@ -38,6 +41,11 @@ export default function ModelsLayout({
 
   return (
     <div className={classes.root}>
+      <Head>
+        <title>{brand}</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
       <header className={classes.header}>
         {/* NAVIGATION LINKS */}
         <div className={classes.navLinks}>
@@ -45,7 +53,7 @@ export default function ModelsLayout({
 
           <SiteLink href="/" className={classes.navlink}>
             <HomeIcon />
-            <span>{brand ?? 'Zendro'}</span>
+            <span>{brand}</span>
           </SiteLink>
 
           <ClientOnly>
@@ -77,34 +85,28 @@ export default function ModelsLayout({
         </div>
       </header>
 
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          flexGrow: 1,
-        }}
-      >
-        {props.children}
-      </div>
+      {props.children}
 
-      <footer className={classes.footer}>
-        <a
-          className={classes.footerLink}
-          href="https://nextjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span>Powered by</span>
-          <img
-            style={{
-              paddingLeft: '.5rem',
-            }}
-            src="/nextjs.svg"
-            alt="Next Logo"
-            className={classes.footerLogo}
-          />
-        </a>
-      </footer>
+      {footer && (
+        <footer className={classes.footer}>
+          <a
+            className={classes.footerLink}
+            href="https://nextjs.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span>Powered by</span>
+            <img
+              style={{
+                paddingLeft: '.5rem',
+              }}
+              src="/nextjs.svg"
+              alt="Next Logo"
+              className={classes.footerLogo}
+            />
+          </a>
+        </footer>
+      )}
     </div>
   );
 }
@@ -114,8 +116,8 @@ const useStyles = makeStyles((theme) => {
     root: {
       display: 'flex',
       flexDirection: 'column',
-      height: '100%',
-      overflowX: 'hidden',
+      flexGrow: 1,
+      minHeight: '100vh',
     },
     header: {
       // Layout

--- a/src/layouts/models/model-layout.tsx
+++ b/src/layouts/models/model-layout.tsx
@@ -26,10 +26,9 @@ export interface ModelLayoutProps {
   routes?: AppRoutes2;
 }
 
-export default function ModelLayout({
-  routes,
-  children,
-}: PropsWithChildren<ModelLayoutProps>): ReactElement {
+export default function ModelLayout(
+  props: PropsWithChildren<ModelLayoutProps>
+): ReactElement {
   const classes = useStyles();
   const router = useRouter();
   const routePath = useRef(router.asPath);
@@ -67,9 +66,11 @@ export default function ModelLayout({
           </Fab>
         </Zoom>
       }
+      brand={props.brand}
+      footer={false}
     >
-      <Models showNav={showNav} routes={routes ?? appRoutes}>
-        {children}
+      <Models showNav={showNav} routes={props.routes ?? appRoutes}>
+        {props.children}
       </Models>
     </AppLayout>
   );

--- a/src/layouts/models/model-main.tsx
+++ b/src/layouts/models/model-main.tsx
@@ -67,7 +67,7 @@ export default function Models({
     });
 
   return (
-    <div className={classes.mainContainer}>
+    <div className={classes.container}>
       <Navigation
         className={clsx(classes.navDrawer, {
           [classes.navDrawerClosed]: !showNav,
@@ -76,8 +76,8 @@ export default function Models({
         routes={routes}
       />
       <main
-        className={clsx(classes.mainContent, {
-          [classes.mainContentShift]: showNav,
+        className={clsx(classes.content, {
+          [classes.contentShift]: showNav,
         })}
       >
         <Breadcrumbs
@@ -116,19 +116,23 @@ const useStyles = makeStyles((theme) => {
       height: theme.spacing(14),
       padding: theme.spacing(0, 4),
     },
-    mainContainer: {
+    container: {
       display: 'flex',
       flexGrow: 1,
-      height: `calc(100% - ${theme.spacing(18)})`,
+      overflowY: 'hidden',
+      maxHeight: `calc(100vh - ${theme.spacing(18)})`,
     },
-    mainContent: {
+    content: {
       display: 'flex',
       flexDirection: 'column',
-      width: '100%',
+      flexGrow: 1,
+      // maxHeight: `calc(100% - ${theme.spacing(32)})`,
+
       transition: theme.transitions.create(['width'], {
         duration: theme.transitions.duration.standard,
         easing: theme.transitions.easing.sharp,
       }),
+
       [theme.breakpoints.down('md')]: {
         opacity: 100,
         transition: theme.transitions.create(['opacity'], {
@@ -137,7 +141,7 @@ const useStyles = makeStyles((theme) => {
         }),
       },
     },
-    mainContentShift: {
+    contentShift: {
       [theme.breakpoints.down('md')]: {
         opacity: 0,
         transition: theme.transitions.create(['opacity'], {

--- a/src/pages/[group]/[model]/details.tsx
+++ b/src/pages/[group]/[model]/details.tsx
@@ -161,7 +161,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             disabled={model.schema.associations?.length === 0}
           />
         </TabList>
-        <TabPanel value="attributes">
+        <TabPanel className={classes.tabPanel} value="attributes">
           <AttributesForm
             attributes={model.schema.attributes}
             data={recordData}
@@ -176,7 +176,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             }}
           />
         </TabPanel>
-        <TabPanel value="associations" className={classes.tabPanel}>
+        <TabPanel className={classes.tabPanel} value="associations">
           <AssociationsTable
             associationView="details"
             associations={model.schema.associations ?? []}
@@ -216,8 +216,11 @@ const useStyles = makeStyles((theme) =>
       },
     },
     tabPanel: {
-      display: 'flex',
-      flexGrow: 1,
+      '&&:not([hidden])': {
+        display: 'flex',
+        flexGrow: 1,
+        overflowY: 'auto',
+      },
     },
   })
 );

--- a/src/pages/[group]/[model]/edit.tsx
+++ b/src/pages/[group]/[model]/edit.tsx
@@ -302,7 +302,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
             disabled={model.schema.associations?.length === 0}
           />
         </TabList>
-        <TabPanel value="attributes">
+        <TabPanel className={classes.tabPanel} value="attributes">
           <AttributesForm
             attributes={model.schema.attributes}
             data={recordData}
@@ -359,8 +359,11 @@ const useStyles = makeStyles((theme) =>
       },
     },
     tabPanel: {
-      display: 'flex',
-      flexGrow: 1,
+      '&&:not([hidden])': {
+        display: 'flex',
+        flexGrow: 1,
+        overflowY: 'auto',
+      },
     },
   })
 );

--- a/src/pages/[group]/[model]/index.tsx
+++ b/src/pages/[group]/[model]/index.tsx
@@ -322,7 +322,7 @@ const Model: PageWithLayout<ModelProps> = (props) => {
 
   return (
     <ModelBouncer object={props.model} action="read">
-      <TableContainer className={classes.root}>
+      <TableContainer className={classes.tableContainer}>
         <div className={classes.toolbar}>
           <TableSearch
             placeholder={t('model-table.search-label', {
@@ -394,6 +394,7 @@ const Model: PageWithLayout<ModelProps> = (props) => {
             </a>
           </div>
         </div>
+
         <Table caption={t('model-table.caption', { modelName: props.model })}>
           <TableHeader
             actionsColSpan={
@@ -493,12 +494,11 @@ const Model: PageWithLayout<ModelProps> = (props) => {
 
 const useStyles = makeStyles((theme) =>
   createStyles({
-    root: {
+    tableContainer: {
       display: 'flex',
       flexDirection: 'column',
       width: '100%',
       flexGrow: 1,
-      overflow: 'auto',
       padding: theme.spacing(2, 4),
       marginTop: theme.spacing(8),
     },

--- a/src/pages/[group]/[model]/new.tsx
+++ b/src/pages/[group]/[model]/new.tsx
@@ -2,6 +2,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
 
 import { getStaticModelPaths } from '@/build/routes';
 import { useDialog } from '@/components/dialog-popup';
@@ -43,6 +44,7 @@ export const getStaticProps: GetStaticProps<
 };
 
 const Record: PageWithLayout<RecordProps> = (props) => {
+  const classes = useStyles();
   const dialog = useDialog();
   const model = useModel(props.model);
   const router = useRouter();
@@ -148,6 +150,7 @@ const Record: PageWithLayout<RecordProps> = (props) => {
   return (
     <ModelBouncer object={props.model} action="create">
       <AttributesForm
+        className={classes.form}
         attributes={model.schema.attributes}
         errors={ajvErrors}
         formId={router.asPath}
@@ -161,6 +164,15 @@ const Record: PageWithLayout<RecordProps> = (props) => {
     </ModelBouncer>
   );
 };
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    form: {
+      marginTop: theme.spacing(6),
+      overflowY: 'auto',
+    },
+  })
+);
 
 Record.layout = ModelLayout;
 export default Record;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import { makeStyles, createStyles, Theme } from '@material-ui/core';
 import { AppLayout, PageWithLayout } from '@/layouts';
 import { useTranslation } from 'react-i18next';
@@ -9,40 +8,33 @@ const Home: PageWithLayout = () => {
   const { t } = useTranslation();
 
   return (
-    <div className={classes.container}>
-      <Head>
-        <title>Zendro App</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+    <main className={classes.main}>
+      <img className={classes.banner} src="/banner.png" alt="zendro banner" />
 
-      <main className={classes.main}>
-        <img className={classes.banner} src="/banner.png" alt="zendro banner" />
+      <ClientOnly>
+        <div className={classes.cardContainer}>
+          <a
+            className={classes.card}
+            href="https://zendro-dev.github.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h1>{t('home.documentation')} &rarr;</h1>
+            <p>{t('home.documentation-info')}</p>
+          </a>
 
-        <ClientOnly>
-          <div className={classes.cardContainer}>
-            <a
-              className={classes.card}
-              href="https://zendro-dev.github.io"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <h1>{t('home.documentation')} &rarr;</h1>
-              <p>{t('home.documentation-info')}</p>
-            </a>
-
-            <a
-              className={classes.card}
-              href="https://github.com/Zendro-dev"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <h1>Github &rarr;</h1>
-              <p>{t('home.github-info')}</p>
-            </a>
-          </div>
-        </ClientOnly>
-      </main>
-    </div>
+          <a
+            className={classes.card}
+            href="https://github.com/Zendro-dev"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h1>Github &rarr;</h1>
+            <p>{t('home.github-info')}</p>
+          </a>
+        </div>
+      </ClientOnly>
+    </main>
   );
 };
 
@@ -68,7 +60,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     banner: {
       padding: theme.spacing(8),
-      width: '100%',
       objectFit: 'contain',
     },
     cardContainer: {

--- a/src/zendro/model-table/table-body.tsx
+++ b/src/zendro/model-table/table-body.tsx
@@ -1,7 +1,11 @@
 import { PropsWithChildren, ReactElement } from 'react';
-import { TableBody as MuiTableBody, Fade } from '@material-ui/core';
+import {
+  Fade,
+  TableBody as MuiTableBody,
+  TableBodyProps as MuiTableBodyProps,
+} from '@material-ui/core';
 
-interface TableBodyProps {
+interface TableBodyProps extends MuiTableBodyProps {
   isLoading?: boolean;
 }
 
@@ -11,7 +15,7 @@ export default function TableBody({
 }: PropsWithChildren<TableBodyProps>): ReactElement {
   return (
     <Fade in={!isLoading}>
-      <MuiTableBody>{props.children}</MuiTableBody>
+      <MuiTableBody {...props}>{props.children}</MuiTableBody>
     </Fade>
   );
 }

--- a/src/zendro/model-table/table.tsx
+++ b/src/zendro/model-table/table.tsx
@@ -57,7 +57,6 @@ const useStyles = makeStyles(() =>
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
-      overflow: 'auto',
     },
     tablePlaceholder: {
       position: 'absolute',

--- a/src/zendro/record-form/form-utils.ts
+++ b/src/zendro/record-form/form-utils.ts
@@ -39,7 +39,7 @@ export function initForm({
         type,
         primaryKey,
         readOnly: formView === 'update' && primaryKey,
-        value: data?.[name] ?? null,
+        value: (data?.[name] as AttributeValue) ?? null,
         serverErrors: errors?.[name],
       });
 
@@ -75,7 +75,7 @@ function updateValues(
 ): FormAttribute[] {
   const { data } = payload;
   return state.map((attribute) => {
-    attribute.value = data[attribute.name];
+    attribute.value = data[attribute.name] as AttributeValue;
     return attribute;
   });
 }
@@ -121,7 +121,7 @@ export function formAttributesReducer(
 
 /* UTILITY FUNCTIONS */
 
-interface FormStats {
+export interface FormStats {
   clientErrors: number;
   unset: number;
 }
@@ -150,7 +150,7 @@ export function computeStats(formAttributes: FormAttribute[]): FormStats {
  */
 export function computeDiffs(
   formData: FormAttribute[],
-  recordData: Record<string, AttributeValue>
+  recordData: DataRecord
 ): number {
   return formData.reduce((acc, { name, value }) => {
     const cachedValue = recordData[name];

--- a/src/zendro/record-form/form.tsx
+++ b/src/zendro/record-form/form.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Container, Tooltip } from '@material-ui/core';
+import { Container, ContainerProps, Tooltip } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import {
   Cached as Reload,
@@ -29,7 +29,12 @@ import { isNullorEmpty } from '@/utils/validation';
 import FormErrors from './form-errors';
 import FormHeader from './form-header';
 import FormField from './form-field';
-import { formAttributesReducer, computeStats, initForm } from './form-utils';
+import {
+  computeStats,
+  formAttributesReducer,
+  FormStats,
+  initForm,
+} from './form-utils';
 
 type FormAction = 'cancel' | 'delete' | 'read' | 'reload' | 'update' | 'submit';
 export type ActionHandler = (
@@ -37,20 +42,6 @@ export type ActionHandler = (
   stats: FormStats,
   callback?: () => void
 ) => void;
-
-export interface AttributesFormProps {
-  actions?: Partial<Record<FormAction, ActionHandler>>;
-  // actions2?: { [key in FormAction]?: ActionHandler };
-  attributes: ParsedAttribute[];
-  className?: string;
-  data?: DataRecord;
-  disabled?: boolean;
-  errors?: Record<string, string[]>;
-  formId: string;
-  formView: FormView;
-  info?: ReactNode;
-  modelName: string;
-}
 
 export interface FormAttribute extends ParsedAttribute {
   serverErrors?: string[];
@@ -61,15 +52,22 @@ export interface FormAttribute extends ParsedAttribute {
 
 export type FormView = 'create' | 'read' | 'update';
 
-interface FormStats {
-  clientErrors: number;
-  unset: number;
+export interface AttributesFormProps extends ContainerProps {
+  actions?: Partial<Record<FormAction, ActionHandler>>;
+  // actions2?: { [key in FormAction]?: ActionHandler };
+  attributes: ParsedAttribute[];
+  data?: DataRecord;
+  disabled?: boolean;
+  errors?: Record<string, string[]>;
+  formId: string;
+  formView: FormView;
+  info?: ReactNode;
+  modelName: string;
 }
 
 export default function AttributesForm({
   actions,
   attributes,
-  className,
   disabled,
   data,
   errors,
@@ -165,7 +163,7 @@ export default function AttributesForm({
   };
 
   return (
-    <Container maxWidth="lg" className={className}>
+    <Container maxWidth="lg" {...props}>
       <div className={classes.actionsContainer}>
         {actions?.cancel && (
           <ActionButton


### PR DESCRIPTION
## Summary

This PR addresses various style and formatting issues that affected both the application and models layouts.

## Changes

### Application Layout

- Add a new `footer` prop to support rendering the footer conditionally.
- Remove the artificial content wrapper; now only the header and footer are specifically styled.
- Set the minimum height to `100vh` and grow with the parent (`body`->`next`).

### Model Layout
- Do not render the footer in model table and record pages.
- Correctly scale the maximum layout height to 100vh and resize the content accordingly.

### Pages
- Site Home: do not wrap `main` and move the `Head` component to the layout.
- Model: defer overflow handling to the layout.
- New: add missing top margin.
- Allow all tabs to grow within their flex container.
- Handle overflowing content via scroll bar.
- Fallback to regular tab behavior if the panel is hidden
- In the `new` record page, handle form overflow via a direct form class. 

### Table
- The table-body now inherits props from the appropriate Mui component.
- Defer overflow handling to the parent layout.

### Form
- Remove a duplicate `FormStats` interface.
- Inherit props from the Mui Container component that wraps the form
