### PR TITLE
feat: storage type routes

### DIFF
--- a/src/build/models.preval.ts
+++ b/src/build/models.preval.ts
@@ -1,13 +1,13 @@
 import preval from 'next-plugin-preval';
 import { ParsedDataModel2 } from '@/types/models';
-import { getAttributeList, parseAssociations } from '@/utils/models';
+import { parseAttributes, parseAssociations } from '@/utils/models';
 import { getStaticModels } from './models';
 
 async function buildModels(): Promise<Record<string, ParsedDataModel2>> {
   const models = await getStaticModels();
 
   return Object.entries(models).reduce((acc, [name, schema]) => {
-    const attributes = getAttributeList(schema, { excludeForeignKeys: true });
+    const attributes = parseAttributes(schema, { excludeForeignKeys: true });
     const associations = parseAssociations(schema);
     return {
       ...acc,

--- a/src/build/models.preval.ts
+++ b/src/build/models.preval.ts
@@ -1,23 +1,30 @@
 import preval from 'next-plugin-preval';
-import { ParsedDataModel2 } from '@/types/models';
-import { parseAttributes, parseAssociations } from '@/utils/models';
+import { ParsedDataModel } from '@/types/models';
 import { getStaticModels } from './models';
 
-async function buildModels(): Promise<Record<string, ParsedDataModel2>> {
+async function buildModels(): Promise<Record<string, ParsedDataModel>> {
   const models = await getStaticModels();
 
-  return Object.entries(models).reduce((acc, [name, schema]) => {
-    const attributes = parseAttributes(schema, { excludeForeignKeys: true });
-    const associations = parseAssociations(schema);
-    return {
-      ...acc,
-      [name]: {
-        ...schema,
-        associations,
-        attributes,
-      },
-    };
-  }, {} as Promise<Record<string, ParsedDataModel2>>);
+  // Filter out foreign key attributes
+  const dataModelEntries = Object.entries(models).map(
+    ([modelName, modelData]) => {
+      const attributes = modelData.attributes.filter(
+        (attribute) => !attribute.foreignKey
+      );
+
+      return [
+        modelName,
+        {
+          ...modelData,
+          attributes,
+        },
+      ];
+    }
+  );
+
+  const dataModels = Object.fromEntries(dataModelEntries);
+
+  return dataModels;
 }
 
 export default preval(buildModels());

--- a/src/build/models.ts
+++ b/src/build/models.ts
@@ -47,10 +47,10 @@ export async function getStaticModels(): Promise<
   const dataModels = await readdir('./models');
   const adminModels = await readdir('./admin');
 
-  for (const file of [...adminModels, ...dataModels]) {
-    const { name } = parse(file);
-    const dataModel = await getStaticModel(name);
-    models[name] = dataModel;
+  for (const filePath of [...adminModels, ...dataModels]) {
+    const file = parse(filePath);
+    const dataModel = await getStaticModel(file.name);
+    models[file.name] = dataModel;
   }
 
   return models;

--- a/src/build/models.ts
+++ b/src/build/models.ts
@@ -1,113 +1,6 @@
 import { readdir, readFile, stat } from 'fs/promises';
 import { parse } from 'path';
-import { DataModel, ParsedDataModel, ParsedDataModel3 } from '@/types/models';
-import { parseAssociations, parseAttributes } from '@/utils/models';
-
-interface StaticModels {
-  [name: string]: DataModel;
-}
-interface ParsedModels {
-  admin: { [name: string]: ParsedDataModel3 };
-  models: { [name: string]: ParsedDataModel3 };
-}
-
-/**
- * Parse each data model into its javascript object representation.
- * @param modelPaths array of paths to each data model file
- */
-export async function getStaticModels2(): Promise<ParsedModels> {
-  const adminModelNames = await readdir('./admin');
-  const dataModelNames = await readdir('./models');
-
-  const loadModels = async (
-    modelFile: string,
-    modelsObject: StaticModels
-  ): Promise<StaticModels> => {
-    const parsedFile = parse(modelFile);
-    const staticModel = await loadStaticModel(parsedFile.name);
-    return {
-      ...modelsObject,
-      [parsedFile.name]: staticModel,
-    };
-  };
-
-  let adminModels: StaticModels = {};
-  for (const file of adminModelNames)
-    adminModels = await loadModels(file, adminModels);
-
-  let dataModels: StaticModels = {};
-  for (const file of [...adminModelNames, ...dataModelNames]) {
-    dataModels = await loadModels(file, dataModels);
-  }
-
-  const parseModels = <
-    T extends ParsedModels['admin'] | ParsedModels['models']
-  >(
-    acc: T,
-    [name, schema]: [string, DataModel]
-  ): T => {
-    const attributes = parseAttributes(schema, { excludeForeignKeys: true });
-    const associations = schema.associations
-      ? parseAssociations(schema)
-      : undefined;
-    const primaryKey = Object.keys(attributes)[0];
-    return {
-      ...acc,
-      [name]: {
-        ...schema,
-        attributes,
-        associations,
-        primaryKey,
-      },
-    };
-  };
-
-  const admin = Object.entries(adminModels).reduce<ParsedModels['admin']>(
-    parseModels,
-    {}
-  );
-
-  const models = Object.entries(dataModels).reduce<ParsedModels['models']>(
-    parseModels,
-    {}
-  );
-
-  return {
-    admin,
-    models,
-  };
-}
-
-/**
- * Parse a data model into its javascript object representation.
- * @param name name of the model to parse
- */
-export async function loadStaticModel(name: string): Promise<DataModel> {
-  const modelPath = await whichModel(name);
-  const json = await readFile(modelPath, { encoding: 'utf8' });
-  const dataModel = JSON.parse(json) as DataModel;
-  return dataModel;
-}
-
-/**
- * Finds the path of a static model.
- * @param name model name
- */
-export async function whichModel(name: string): Promise<string> {
-  let modelPath: string;
-
-  try {
-    await stat(`./models/${name}.json`);
-    modelPath = `./models/${name}.json`;
-  } catch {
-    await stat(`./admin/${name}.json`);
-    modelPath = `./admin/${name}.json`;
-  }
-
-  return modelPath;
-}
-
-/* DEPRECATED */
+import { DataModel, ParsedDataModel } from '@/types/models';
 
 /**
  * Parse a data model into its javascript object representation.
@@ -142,4 +35,22 @@ export async function getStaticModels(): Promise<
   }
 
   return models;
+}
+
+/**
+ * Finds the path of a static model.
+ * @param name model name
+ */
+export async function whichModel(name: string): Promise<string> {
+  let modelPath: string;
+
+  try {
+    await stat(`./models/${name}.json`);
+    modelPath = `./models/${name}.json`;
+  } catch {
+    await stat(`./admin/${name}.json`);
+    modelPath = `./admin/${name}.json`;
+  }
+
+  return modelPath;
 }

--- a/src/build/models.ts
+++ b/src/build/models.ts
@@ -50,7 +50,7 @@ export async function getStaticModels(): Promise<
   for (const filePath of [...adminModels, ...dataModels]) {
     const file = parse(filePath);
     const dataModel = await getStaticModel(file.name);
-    models[file.name] = dataModel;
+    models[dataModel.model] = dataModel;
   }
 
   return models;

--- a/src/build/queries.ts
+++ b/src/build/queries.ts
@@ -1,6 +1,6 @@
 import { ParsedDataModel } from '@/types/models';
 import { StaticAssocQueries, StaticQueries } from '@/types/static';
-import { getAttributeList, parseAssociations } from '@/utils/models';
+import { parseAttributes, parseAssociations } from '@/utils/models';
 import {
   queryBulkCreate,
   queryCsvTemplate,
@@ -21,7 +21,7 @@ export async function getStaticQueries(): Promise<
   const dataModels = await getStaticModels();
 
   Object.entries(dataModels).map(([name, schema]) => {
-    const attributes = getAttributeList(schema, { excludeForeignKeys: true });
+    const attributes = parseAttributes(schema, { excludeForeignKeys: true });
     const associations = parseAssociations(schema);
     const recordQueries = queryRecord(name, attributes, associations);
 
@@ -59,7 +59,7 @@ export function getStaticAssociationQueries(
     { target, type, reverseAssociation },
   ] of Object.entries(sourceModel.associations)) {
     const targetModel = targetModels[target];
-    const targetAttributes = getAttributeList(targetModel, {
+    const targetAttributes = parseAttributes(targetModel, {
       excludeForeignKeys: true,
     });
     if (!targetModel.associations?.[reverseAssociation])
@@ -72,7 +72,7 @@ export function getStaticAssociationQueries(
       readOneRecordWithToMany,
     } = readOneRecordWithAssoc(
       sourceModel.model,
-      getAttributeList(sourceModel, { excludeForeignKeys: true }),
+      parseAttributes(sourceModel, { excludeForeignKeys: true }),
       associationName,
       target,
       targetAttributes
@@ -80,7 +80,7 @@ export function getStaticAssociationQueries(
 
     const readAllWithToOne = queryRecordsWithToOne(
       target,
-      getAttributeList(targetModel, { excludeForeignKeys: true }),
+      parseAttributes(targetModel, { excludeForeignKeys: true }),
       reverseAssociation,
       sourceModel.model,
       sourceModel.primaryKey
@@ -88,7 +88,7 @@ export function getStaticAssociationQueries(
 
     const readAllWithToMany = queryRecordsWithToMany(
       target,
-      getAttributeList(targetModel, { excludeForeignKeys: true }),
+      parseAttributes(targetModel, { excludeForeignKeys: true }),
       reverseAssociation,
       sourceModel.model,
       sourceModel.primaryKey

--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -169,10 +169,10 @@ export async function getStaticAssociationPaths(): Promise<
       const model = route.name;
       const { associations } = await getStaticModel(model);
       if (associations) {
-        Object.keys(associations).forEach((association) =>
+        associations.forEach((assoc) =>
           requests.forEach((request) => {
             associationPaths.push({
-              params: { group, model, request, association },
+              params: { group, model, request, association: assoc.name },
             });
           })
         );

--- a/src/hooks/useModel.ts
+++ b/src/hooks/useModel.ts
@@ -2,15 +2,12 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import dataModels from '@/build/models.preval';
 import { authSelector } from '@/store/auth-slice';
-import { ApiPrivileges, ParsedDataModel2 } from '@/types/models';
+import { ParsedDataModel } from '@/types/models';
 import { ParsedPermissions } from '@/types/acl';
 import { getResourcePermissions } from '@/utils/acl';
-import { getModelApiPrivileges } from '@/utils/models';
 
-interface Model {
+interface Model extends ParsedDataModel {
   permissions: ParsedPermissions;
-  apiPrivileges: ApiPrivileges;
-  schema: ParsedDataModel2;
 }
 
 type GetModel = (modelName: string) => Model;
@@ -24,14 +21,9 @@ export function useModel(modelName?: string): Model | GetModel {
     (modelName: string): Model => {
       const permissions = getResourcePermissions(modelName, user?.permissions);
 
-      const apiPrivileges = getModelApiPrivileges(
-        dataModels[modelName].storageType
-      );
-
       return {
+        ...dataModels[modelName],
         permissions,
-        apiPrivileges,
-        schema: dataModels[modelName],
       };
     },
     [user?.permissions]

--- a/src/pages/[group]/[model]/[request]/[association]/index.tsx
+++ b/src/pages/[group]/[model]/[request]/[association]/index.tsx
@@ -88,7 +88,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
   const urlQuery = router.query as AssociationUrlQuery;
 
   const sourceModel = getModel(props.model);
-  const association = sourceModel.schema.associations?.find(
+  const association = sourceModel.associations?.find(
     (assoc) => assoc.name === props.association
   ) as ParsedAssociation;
   const targetModel = getModel(association.target);
@@ -123,8 +123,8 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
   const [searchText, setSearchText] = useState('');
   const tableSearch = useTableSearch({
     associationFilter: recordsFilter,
-    attributes: targetModel.schema.attributes,
-    primaryKey: targetModel.schema.primaryKey,
+    attributes: targetModel.attributes,
+    primaryKey: targetModel.primaryKey,
     selectedRecords,
     searchText,
   });
@@ -201,9 +201,9 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
         order: tableOrder,
         pagination: tablePagination,
         assocPagination: { first: 1 },
-        [sourceModel.schema.primaryKey]: urlQuery.id,
+        [sourceModel.primaryKey]: urlQuery.id,
         assocSearch: {
-          field: sourceModel.schema.primaryKey,
+          field: sourceModel.primaryKey,
           value: urlQuery.id,
           operator: 'eq',
         },
@@ -222,7 +222,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
           recordsFilter === 'associated'
             ? undefined
             : recordsQuery.assocResolver;
-        const assocPrimaryKey = sourceModel.schema.primaryKey;
+        const assocPrimaryKey = sourceModel.primaryKey;
         const assocPrimaryKeyValue = urlQuery.id as string;
 
         const parsedRecords = data.records.reduce<TableRecord[]>(
@@ -292,7 +292,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
 
       const variables: QueryModelTableRecordsVariables = {
         search: tableSearch,
-        [sourceModel.schema.primaryKey]: urlQuery.id,
+        [sourceModel.primaryKey]: urlQuery.id,
       };
 
       return await zendro.request(countQuery.query, {
@@ -323,7 +323,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
     );
 
     const currAssocRecordId = currAssocRecord
-      ? (currAssocRecord.data[targetModel.schema.primaryKey] as string | number)
+      ? (currAssocRecord.data[targetModel.primaryKey] as string | number)
       : undefined;
 
     switch (action) {
@@ -375,7 +375,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
       ? nameCp
       : namePlCp;
     const variables = {
-      [sourceModel.schema.primaryKey]: urlQuery.id,
+      [sourceModel.primaryKey]: urlQuery.id,
       [`add${mutationName}`]:
         selectedRecords.toAdd.length > 0
           ? association.type.includes('to_one')
@@ -433,7 +433,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
           {
             type: 'group',
             label: props.association,
-            links: sourceModel.schema.associations?.map((assoc) => ({
+            links: sourceModel.associations?.map((assoc) => ({
               type: 'link',
               label: assoc.name,
               href: `/${props.group}/${props.model}/${props.request}/${assoc.name}?id=${urlQuery.id}`,
@@ -536,7 +536,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
           >
             <TableHeader
               actionsColSpan={props.request !== 'details' ? 1 : 0}
-              attributes={targetModel.schema.attributes}
+              attributes={targetModel.attributes}
               onSortLabelClick={(field) =>
                 setOrder((state) => ({
                   ...state,
@@ -548,14 +548,14 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
                     : 'ASC',
                 }))
               }
-              activeOrder={order?.sortField ?? targetModel.schema.primaryKey}
+              activeOrder={order?.sortField ?? targetModel.primaryKey}
               orderDirection={order?.sortDirection ?? 'ASC'}
               disableSort={!targetModel.apiPrivileges.sort}
             />
 
             <TableBody>
               {assocTable.data.map((record) => {
-                const recordPK = targetModel.schema.primaryKey;
+                const recordPK = targetModel.primaryKey;
                 const recordId = record.data[recordPK] as string | number;
                 const isSelected =
                   selectedRecords.toAdd.includes(recordId) ||
@@ -564,7 +564,7 @@ const Association: PageWithLayout<AssociationUrlQuery> = (props) => {
                   <TableRow
                     key={recordId}
                     hover
-                    attributes={targetModel.schema.attributes}
+                    attributes={targetModel.attributes}
                     record={record.data}
                   >
                     {props.request !== 'details' && (

--- a/src/pages/[group]/[model]/[request]/index.tsx
+++ b/src/pages/[group]/[model]/[request]/index.tsx
@@ -56,7 +56,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
   /* STATE */
 
   const [recordData, setRecordData] = useState<DataRecord>({
-    [model.schema.primaryKey]: urlQuery.id ?? null,
+    [model.primaryKey]: urlQuery.id ?? null,
   });
   const [ajvErrors, setAjvErrors] = useState<Record<string, string[]>>();
 
@@ -134,7 +134,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
         try {
           const query = zendro.queries[props.model].deleteOne.query;
           const variables = {
-            [model.schema.primaryKey]: recordData[model.schema.primaryKey],
+            [model.primaryKey]: recordData[model.primaryKey],
           };
           await zendro.request(query, { variables });
           router.push(`/${props.group}/${props.model}`);
@@ -203,7 +203,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
         mutateRecord(response[request.resolver]);
 
         if (props.request === 'new') {
-          const newId = response[request.resolver][model.schema.primaryKey];
+          const newId = response[request.resolver][model.primaryKey];
           router.push(`/${props.group}/${props.model}/edit?id=${newId}`);
         } else {
           router.push(`/${props.group}/${props.model}`);
@@ -254,7 +254,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
     async () => {
       const request = zendro.queries[props.model].readOne;
       const variables = {
-        [model.schema.primaryKey]: urlQuery.id,
+        [model.primaryKey]: urlQuery.id,
       };
       const response = await zendro.request<Record<string, DataRecord>>(
         request.query,
@@ -268,7 +268,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
       onSuccess: (data) => {
         setRecordData(
           data ?? {
-            [model.schema.primaryKey]: urlQuery.id ?? null,
+            [model.primaryKey]: urlQuery.id ?? null,
           }
         );
         setAjvErrors(undefined);
@@ -303,7 +303,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
             links:
               props.request === 'new'
                 ? []
-                : model.schema.associations?.map((assoc) => ({
+                : model.associations?.map((assoc) => ({
                     type: 'link',
                     label: assoc.name,
                     href: `/${props.group}/${props.model}/${props.request}/${assoc.name}?id=${urlQuery.id}`,
@@ -313,7 +313,7 @@ const Record: PageWithLayout<RecordUrlQuery> = (props) => {
       />
 
       <AttributesForm
-        attributes={model.schema.attributes}
+        attributes={model.attributes}
         className={classes.root}
         data={recordData}
         disabled={props.request === 'details'}

--- a/src/pages/[group]/[model]/index.tsx
+++ b/src/pages/[group]/[model]/index.tsx
@@ -114,8 +114,8 @@ const Model: PageWithLayout<ModelProps> = (props) => {
 
   const [searchText, setSearchText] = useState('');
   const tableSearch = useTableSearch({
-    attributes: model.schema.attributes,
-    primaryKey: model.schema.primaryKey,
+    attributes: model.attributes,
+    primaryKey: model.primaryKey,
     searchText,
   });
 
@@ -249,7 +249,7 @@ const Model: PageWithLayout<ModelProps> = (props) => {
       onOk: async () => {
         const query = zendro.queries[props.model].deleteOne.query;
         const variables = {
-          [model.schema.primaryKey]: primaryKey,
+          [model.primaryKey]: primaryKey,
         };
         try {
           await zendro.request(query, { variables });
@@ -468,7 +468,7 @@ const Model: PageWithLayout<ModelProps> = (props) => {
                 ([action, allowed]) => allowed && action !== 'create'
               ).length
             }
-            attributes={model.schema.attributes}
+            attributes={model.attributes}
             onSortLabelClick={(field) =>
               setOrder((state) => ({
                 ...state,
@@ -480,7 +480,7 @@ const Model: PageWithLayout<ModelProps> = (props) => {
                   : 'ASC',
               }))
             }
-            activeOrder={order?.sortField ?? model.schema.primaryKey}
+            activeOrder={order?.sortField ?? model.primaryKey}
             orderDirection={order?.sortDirection ?? 'ASC'}
             data-cy="record-table-header"
             disableSort={!model.apiPrivileges.sort}
@@ -488,12 +488,10 @@ const Model: PageWithLayout<ModelProps> = (props) => {
 
           <TableBody>
             {records.map((record) => {
-              const recordId = record.data[model.schema.primaryKey] as
-                | string
-                | number;
+              const recordId = record.data[model.primaryKey] as string | number;
               return (
                 <TableRow
-                  attributes={model.schema.attributes}
+                  attributes={model.attributes}
                   record={record.data}
                   key={recordId}
                   onDoubleClick={() => handleOnRead(recordId)}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -41,17 +41,6 @@ export type StorageType =
   | 'presto-adapter'
   | 'neo4j-adapter';
 
-export interface ApiPrivileges {
-  operators: Operator[];
-  textSearch: boolean;
-  backwardPagination: boolean;
-  sort: boolean;
-  create: boolean;
-  update: boolean;
-  delete: boolean;
-  bulkAddCsv: boolean;
-}
-
 export interface Attributes {
   [key: string]: AttributeScalarType | AttributeArrayType;
 }
@@ -109,6 +98,17 @@ export interface ParsedAssociation extends Association {
 
 /* DATA MODELS */
 
+export interface ApiPrivileges {
+  operators: Operator[];
+  textSearch: boolean;
+  backwardPagination: boolean;
+  sort: boolean;
+  create: boolean;
+  update: boolean;
+  delete: boolean;
+  bulkAddCsv: boolean;
+}
+
 export interface DataModel {
   associations?: Record<string, Association>;
   attributes: Attributes;
@@ -117,13 +117,10 @@ export interface DataModel {
   storageType: StorageType;
 }
 
-export interface ParsedDataModel extends DataModel {
-  primaryKey: string;
-}
-
-export type ParsedDataModel2 = Assign<
+export type ParsedDataModel = Assign<
   DataModel,
   {
+    apiPrivileges: ApiPrivileges;
     associations?: ParsedAssociation[];
     attributes: ParsedAttribute[];
     primaryKey: string;

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -129,12 +129,3 @@ export type ParsedDataModel2 = Assign<
     primaryKey: string;
   }
 >;
-
-export type ParsedDataModel3 = Assign<
-  DataModel,
-  {
-    associations?: Record<string, ParsedAssociation>;
-    attributes: Record<string, ParsedAttribute>;
-    primaryKey: string;
-  }
->;

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -51,71 +51,6 @@ export function getForeignKeys(dataModel: DataModel): Set<string> {
 }
 
 /**
- * Read raw associations into a parsed array.
- * @param model parsed data model object
- */
-export function parseAssociations(model: DataModel): ParsedAssociation[] {
-  let parsedAssociations: ParsedAssociation[] = [];
-
-  if (model.associations) {
-    parsedAssociations = Object.entries(model.associations).map(
-      ([name, values]) => ({
-        name,
-        ...values,
-      })
-    );
-  }
-
-  return parsedAssociations;
-}
-
-export function parseAttributes(
-  model: DataModel,
-  options?: {
-    excludeForeignKeys: boolean;
-  }
-): Array<ParsedAttribute> {
-  // Get an array of Attribute objects
-  const foreignKeys = getForeignKeys(model);
-  let attributes: Array<ParsedAttribute> = Object.keys(model.attributes).map(
-    (attribute) => {
-      return {
-        name: attribute,
-        type: model.attributes[attribute],
-        primaryKey: model.internalId === attribute,
-        foreignKey: foreignKeys.has(attribute),
-      };
-    }
-  );
-
-  // Parse all attributes contained in associated models
-  if (options?.excludeForeignKeys) {
-    attributes = attributes.filter(({ foreignKey }) => !foreignKey);
-  }
-
-  // Sort or unshift the id attribute
-  model.internalId
-    ? attributes.splice(
-        0,
-        0,
-        attributes.splice(
-          attributes.findIndex((attr) => {
-            return attr.name === model.internalId;
-          }),
-          1
-        )[0]
-      )
-    : attributes.unshift({
-        name: 'id',
-        type: 'Int',
-        primaryKey: true,
-        automaticId: true,
-      });
-
-  return attributes;
-}
-
-/**
  * Depending on the storageType the model might have some restrictions on certain aspects of the zendro API (search, order, paginate).
  * This function returns those privileges
  *
@@ -256,4 +191,69 @@ export function getModelApiPrivileges(storageType: StorageType): ApiPrivileges {
     default:
       return defaultPrivileges;
   }
+}
+
+/**
+ * Read raw associations into a parsed array.
+ * @param model parsed data model object
+ */
+export function parseAssociations(model: DataModel): ParsedAssociation[] {
+  let parsedAssociations: ParsedAssociation[] = [];
+
+  if (model.associations) {
+    parsedAssociations = Object.entries(model.associations).map(
+      ([name, values]) => ({
+        name,
+        ...values,
+      })
+    );
+  }
+
+  return parsedAssociations;
+}
+
+export function parseAttributes(
+  model: DataModel,
+  options?: {
+    excludeForeignKeys: boolean;
+  }
+): Array<ParsedAttribute> {
+  // Get an array of Attribute objects
+  const foreignKeys = getForeignKeys(model);
+  let attributes: Array<ParsedAttribute> = Object.keys(model.attributes).map(
+    (attribute) => {
+      return {
+        name: attribute,
+        type: model.attributes[attribute],
+        primaryKey: model.internalId === attribute,
+        foreignKey: foreignKeys.has(attribute),
+      };
+    }
+  );
+
+  // Parse all attributes contained in associated models
+  if (options?.excludeForeignKeys) {
+    attributes = attributes.filter(({ foreignKey }) => !foreignKey);
+  }
+
+  // Sort or unshift the id attribute
+  model.internalId
+    ? attributes.splice(
+        0,
+        0,
+        attributes.splice(
+          attributes.findIndex((attr) => {
+            return attr.name === model.internalId;
+          }),
+          1
+        )[0]
+      )
+    : attributes.unshift({
+        name: 'id',
+        type: 'Int',
+        primaryKey: true,
+        automaticId: true,
+      });
+
+  return attributes;
 }


### PR DESCRIPTION
## Summary

This PR ensures that specific attributes and associations pages are not generated for storage types that only support a subset of CRUD requests (e.g. Minio).

## Changes

### Build
- Expose the full data model API to `routes.ts` build functions.
- Depending on the model `storageType`, unsupported CRUD request pages (`update`->`edit`, `create`->`new`) will not be generated.

### Runtime
- The `useModel` hook now exposes a flat `ParsedDataModel` object, rather than separate `schema` and `permissions` keys.

### Chore
- Remove unused `getStaticModel` alternative functions.
- Standardize the `ParsedDataModel` interface to include all parsable data known at build time (`attributes`, `associations`, and `apiPrivileges`).
- Renamed various variables and function names to improve clarity.