### PR TITLE
feat: filter cross-models for Navigation Routes

### DIFF
--- a/src/build/models.ts
+++ b/src/build/models.ts
@@ -170,3 +170,19 @@ export async function parseStaticModels(
     Record<string, ParsedDataModel>
   >({}, models, admin);
 }
+
+/**
+ * Parse a list of parsed Data models models and their associations to filter for cross-table models
+ * @param parsedModels List of parsed Data models.
+ * @returns A list of unique names for models that are representing a sql cross table.
+ */
+export function getCrossModels(parsedModels: ParsedDataModel[]): string[] {
+  const cross_models = parsedModels.reduce<string[]>((acc, curr) => {
+    curr.associations?.forEach((assoc) => {
+      if (assoc.implementation === 'sql_cross_table')
+        acc.push(assoc.keysIn as string);
+    });
+    return acc;
+  }, []);
+  return [...new Set(cross_models)];
+}

--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -7,7 +7,7 @@ import {
   RecordUrlQuery,
   RouteLink,
 } from '@/types/routes';
-import { parseStaticModels } from './models';
+import { parseStaticModels, getCrossModels } from './models';
 import { ParsedDataModel } from '@/types/models';
 
 /**
@@ -33,6 +33,11 @@ export async function parseDataModels(): Promise<{
 export async function getModelNavRoutes(): Promise<AppRoutes> {
   const parsedModels = await parseDataModels();
 
+  const crossModels = {
+    models: getCrossModels(parsedModels.models),
+    admin: getCrossModels(parsedModels.admin),
+  };
+
   const parseModelAsRoute = (group: string) => ({
     model,
   }: ParsedDataModel): RouteLink => {
@@ -54,13 +59,17 @@ export async function getModelNavRoutes(): Promise<AppRoutes> {
       type: 'group',
       name: 'Models',
       icon: 'BubbleChart',
-      routes: parsedModels.models.map(parseModelAsRoute('models')),
+      routes: parsedModels.models
+        .filter((model) => !crossModels.models.includes(model.model))
+        .map(parseModelAsRoute('models')),
     },
     {
       type: 'group',
       name: 'Admin',
       icon: 'SupervisorAccountRounded',
-      routes: parsedModels.admin.map(parseModelAsRoute('admin')),
+      routes: parsedModels.admin
+        .filter((model) => !crossModels.admin.includes(model.model))
+        .map(parseModelAsRoute('admin')),
     },
   ];
 }


### PR DESCRIPTION
## Summary

This PR implements a utility to parse the data-models (via associations) into a list of cross-models. This utility is then used to filter Navigation Routes for admin and user-defined models for cross-models. Those are not rendered in the navigation side bar. Theoretically they are still available via the URL bar.

## Changes
- add cross-model utility in models util
- filter for cross-models in `getModelNavRoutes`. Both admin and user-defined models 