### PR TITLE
fix: validate if search value is a number

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,6 +1,6 @@
 import { ParsedAttribute } from '@/types/models';
 import { QueryVariableSearch } from '@/types/queries';
-import { isIntValue } from './validation';
+import { isIntValue, isNumber } from './validation';
 
 export function createSearch(
   value: string,
@@ -9,13 +9,13 @@ export function createSearch(
   const operator = 'or';
 
   const search = attributes.reduce((acc, { name, type }) => {
-    if (type === 'Int' && isIntValue(value)) {
+    if (type === 'Int' && isNumber(value) && isIntValue(value)) {
       acc.push({
         field: name,
         value,
         operator: 'eq',
       });
-    } else if (type === 'Float' && !isNaN(parseFloat(value))) {
+    } else if (type === 'Float' && isNumber(value) && !isNaN(parseFloat(value))) {
       acc.push({
         field: name,
         value,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -56,6 +56,15 @@ export function isObject(x: unknown): x is Record<string, unknown> {
 }
 
 /**
+ * Check whether a given string value is a number.
+ * @param value string to check 
+ * @returns wheter the given value is a valid number (float or integer)
+ */
+ export function isNumber(value: string): boolean {
+  return /(^\d+(?:\.\d+)?)+$/.test(value)
+}
+
+/**
  * Check whether a given string value (e.g. from an input) is a valid integer.
  * @param value string to convert and check
  * @returns whether the given value is a valid integer


### PR DESCRIPTION
## Summary
This PR fixes a bug in the search query for strings that contains numbers and special characters or letters (e. g.  '1_3_4_4'). 
## Current Behaviour
If a string contains special characters or letters, but begins with a number, passes validation for int and float types, so the search querys the value in the int and float columns of the model returning an error.

Check if string is a valid integer
![image](https://user-images.githubusercontent.com/52864142/135129134-749d1cd8-a335-4720-b636-5060ce72126d.png)

Check if string is float
![image](https://user-images.githubusercontent.com/52864142/135129015-a1838d72-acfa-44cc-b793-5d4d3eda1106.png)

 In the images above it could be seen that current validations fails for the given string, while the next image shows the fix, that first checks if the given string is a number, so that later can be validated for integer or float.

![image](https://user-images.githubusercontent.com/52864142/135129275-a1bee227-8918-4690-8c8d-821f13aca228.png)


## Changes

* add isNumber function in validation.ts to check whether a string is a number.
* add extra validation in search.ts to first check if given string is a number.

