### PR TITLE
feat: add windows scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p ${PORT:-8080}",
+    "dev:win": "next dev -p 8080",
     "build": "next build",
     "export": "next export",
     "start": "next start -p ${PORT:-8080}",
+    "start:win": "next start -p 8080",
     "serve": "serve -l ${PORT:-8080} ./out",
     "lint": "eslint --ext js,jsx,ts,tsx --fix .",
     "type-check": "tsc --project tsconfig.json --pretty --noEmit",


### PR DESCRIPTION
## Summary

This PR adds scripts to startup the dev and production servers on windows. See https://github.com/Zendro-dev/zendro/pull/9

## Changes

- add `dev:win` and `start:win` scripts