### PR TITLE
hotfix: set @mui/material to fixed version 5.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@mui/icons-material": "^5.8.4",
-    "@mui/material": "^5.9.3",
+    "@mui/material": "=5.13.6",
     "@mui/styles": "^5.9.3",
     "@mui/x-date-pickers": "^5.0.5",
     "@types/acl": "^0.4.41",


### PR DESCRIPTION
Changes in this PR:
 - set `@mui/material` in `package.json` to version `5.13.6`