### PR TITLE
add paired-end foreignkeys support

### DIFF
--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -33,7 +33,7 @@ export function getForeignKeys(dataModel: DataModel): Set<string> {
         case 'one_to_one':
         case 'many_to_one':
         case 'one_to_many':
-          return keys.add(targetKey);
+          return sourceKey ? keys.add(sourceKey) : keys.add(targetKey);
         case 'many_to_many':
           return sourceKey ? keys.add(sourceKey) : keys;
         default:


### PR DESCRIPTION
Changes in this PR:
 - modified `parseAssociationsReducer` to also return the association attributes when having paired-end foreignkeys implementation for `*-to-one` or `one-to-many` associations
   - this was working only for recursive associations yet